### PR TITLE
Add protection support to channel fields

### DIFF
--- a/digilines_inventory/init.lua
+++ b/digilines_inventory/init.lua
@@ -61,6 +61,11 @@ minetest.register_node("digilines_inventory:chest", {
 		return minetest.get_meta(pos):get_inventory():is_empty("main")
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)
+		local name = sender:get_player_name()
+		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+			minetest.record_protection_violation(pos, name)
+			return
+		end
 		if fields.channel ~= nil then
 			minetest.get_meta(pos):set_string("channel",fields.channel)
 		end

--- a/digilines_lcd/init.lua
+++ b/digilines_lcd/init.lua
@@ -107,6 +107,11 @@ minetest.register_node("digilines_lcd:lcd", {
 	end,
 
 	on_receive_fields = function(pos, formname, fields, sender)
+		local name = sender:get_player_name()
+		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+			minetest.record_protection_violation(pos, name)
+			return
+		end
 		if (fields.channel) then
 			minetest.get_meta(pos):set_string("channel", fields.channel)
 		end

--- a/digilines_lightsensor/init.lua
+++ b/digilines_lightsensor/init.lua
@@ -50,6 +50,11 @@ minetest.register_node("digilines_lightsensor:lightsensor", {
 		meta:set_string("formspec", "field[channel;Channel;${channel}]")
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)
+		local name = sender:get_player_name()
+		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+			minetest.record_protection_violation(pos, name)
+			return
+		end
 		if (fields.channel) then
 			minetest.get_meta(pos):set_string("channel", fields.channel)
 		end

--- a/digilines_rtc/init.lua
+++ b/digilines_rtc/init.lua
@@ -46,6 +46,11 @@ minetest.register_node("digilines_rtc:rtc", {
 		meta:set_string("formspec", "field[channel;Channel;${channel}]")
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)
+		local name = sender:get_player_name()
+		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+			minetest.record_protection_violation(pos, name)
+			return
+		end
 		if (fields.channel) then
 			minetest.get_meta(pos):set_string("channel", fields.channel)
 		end


### PR DESCRIPTION
This prevents people from changing channels on devices in other people's protected areas.