### PR TITLE
lcd: make lettering nearer to display

### DIFF
--- a/lcd.lua
+++ b/lcd.lua
@@ -26,10 +26,10 @@ local lcds = {
 	-- on ground
 	--* [1] = {delta = {x = 0, y =-0.4, z = 0}, pitch = math.pi /  2},
 	-- sides
-	[2] = {delta = {x =  0.4, y = 0, z = 0}, yaw = math.pi / -2},
-	[3] = {delta = {x = -0.4, y = 0, z = 0}, yaw = math.pi /  2},
-	[4] = {delta = {x = 0, y = 0, z =  0.4}, yaw = 0},
-	[5] = {delta = {x = 0, y = 0, z = -0.4}, yaw = math.pi},
+	[2] = {delta = {x =  0.437, y = 0, z = 0}, yaw = math.pi / -2},
+	[3] = {delta = {x = -0.437, y = 0, z = 0}, yaw = math.pi /  2},
+	[4] = {delta = {x = 0, y = 0, z =  0.437}, yaw = 0},
+	[5] = {delta = {x = 0, y = 0, z = -0.437}, yaw = math.pi},
 }
 
 local reset_meta = function(pos)
@@ -118,7 +118,7 @@ minetest.register_node("digilines:lcd", {
 		end
 	end,
 
-	digiline = 
+	digiline =
 	{
 		receptor = {},
 		effector = {


### PR DESCRIPTION
fixes #39 

before:
![screenshot_20170208_141933](https://cloud.githubusercontent.com/assets/7613443/22739507/33672c6a-ee0c-11e6-8de3-b970fe002063.png)

after:
![screenshot_20170209_161828](https://cloud.githubusercontent.com/assets/7613443/22789589/b0ca808a-eee3-11e6-9c0b-172ab42e1817.png)

It's actually much more accurate, I hope not too much.

(It will change when the lcd gets a new digiline signal.)