### PR TITLE
Global rename and fixes.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,12 @@
+
+read_globals = {
+	"minetest",
+	"default",
+	"pipeworks",
+	"dump",
+	"VoxelArea",
+}
+
+globals = {
+	"digilines",
+}

--- a/init.lua
+++ b/init.lua
@@ -1,8 +1,42 @@
 
 digilines = {}
 
--- Backwards compat.
-rawset(_G, "digiline", digilines)
+-- Backwards compatibility code.
+-- We define a proxy table whose methods can be called with the
+-- `foo:bar` notation, and it will redirect the call to the
+-- real function, dropping the first implicit argument.
+local digiline; digiline = setmetatable({}, {
+	__index = function(_, k)
+		-- Get method from real table.
+		local v = digilines[k]
+		if type(v) == "function" then
+			-- We need to wrap functions in order to ignore
+			-- the implicit `self` argument.
+			local f = v
+			return function(self, ...)
+				-- Trap invalid calls of the form `digiline.foo(...)`.
+				assert(self == digiline)
+				return f(...)
+			end
+		end
+		return v
+	end,
+})
+rawset(_G, "digiline", digiline)
+
+-- Let's test our proxy table.
+function digilines._testproxy(x)
+	return x
+end
+
+-- Test using old `digiline:foobar` form.
+assert(digiline:_testproxy("foobar") == "foobar")
+
+-- Test using new `digilines.foobar` form.
+assert(digilines._testproxy("foobar") == "foobar")
+
+-- Test calling incorrect form raises an error.
+assert(not pcall(function() digiline._testproxy("foobar") end))
 
 local modpath = minetest.get_modpath("digilines")
 dofile(modpath .. "/presetrules.lua")

--- a/init.lua
+++ b/init.lua
@@ -11,12 +11,12 @@ dofile(modpath .. "/internal.lua")
 dofile(modpath .. "/wires_common.lua")
 dofile(modpath .. "/wire_std.lua")
 
-function digilines:receptor_send(pos, rules, channel, msg)
+function digilines.receptor_send(pos, rules, channel, msg)
 	local checked = {}
 	checked[minetest.hash_node_position(pos)] = true -- exclude itself
 	for _,rule in ipairs(rules) do
-		if digilines:rules_link(pos, digilines:addPosRule(pos, rule)) then
-			digilines:transmit(digilines:addPosRule(pos, rule), channel, msg, checked)
+		if digilines.rules_link(pos, digilines.addPosRule(pos, rule)) then
+			digilines.transmit(digilines.addPosRule(pos, rule), channel, msg, checked)
 		end
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,8 @@
-digiline = {}
+
+digilines = {}
+
+-- Backwards compat.
+rawset(_G, "digiline", digilines)
 
 local modpath = minetest.get_modpath("digilines")
 dofile(modpath .. "/presetrules.lua")
@@ -7,12 +11,12 @@ dofile(modpath .. "/internal.lua")
 dofile(modpath .. "/wires_common.lua")
 dofile(modpath .. "/wire_std.lua")
 
-function digiline:receptor_send(pos, rules, channel, msg)
+function digilines:receptor_send(pos, rules, channel, msg)
 	local checked = {}
 	checked[minetest.hash_node_position(pos)] = true -- exclude itself
 	for _,rule in ipairs(rules) do
-		if digiline:rules_link(pos, digiline:addPosRule(pos, rule)) then
-			digiline:transmit(digiline:addPosRule(pos, rule), channel, msg, checked)
+		if digilines:rules_link(pos, digilines:addPosRule(pos, rule)) then
+			digilines:transmit(digilines:addPosRule(pos, rule), channel, msg, checked)
 		end
 	end
 end

--- a/internal.lua
+++ b/internal.lua
@@ -1,15 +1,15 @@
-function digiline:getspec(node)
+function digilines:getspec(node)
 	if not minetest.registered_nodes[node.name] then return false end
 	return minetest.registered_nodes[node.name].digiline
 end
 
-function digiline:importrules(spec, node)
+function digilines:importrules(spec, node)
 	if type(spec) == 'function' then
 		return spec(node)
 	elseif spec then
 		return spec
 	else
-		return digiline.rules.default
+		return digilines.rules.default
 	end
 end
 
@@ -19,10 +19,10 @@ function digiline:getAnyInputRules(pos)
 	if not spec then return end
 
 	if spec.wire then
-		return digiline:importrules(spec.wire.rules, node)
+		return digilines:importrules(spec.wire.rules, node)
 	end
 	if spec.effector then
-		return digiline:importrules(spec.effector.rules, node)
+		return digilines:importrules(spec.effector.rules, node)
 	end
 end
 
@@ -32,24 +32,24 @@ function digiline:getAnyOutputRules(pos)
 	if not spec then return end
 
 	if spec.wire then
-		return digiline:importrules(spec.wire.rules, node)
+		return digilines:importrules(spec.wire.rules, node)
 	end
 	if spec.receptor then
-		return digiline:importrules(spec.receptor.rules, node)
+		return digilines:importrules(spec.receptor.rules, node)
 	end
 end
 
-function digiline:rules_link(output, input)
-	local outputrules = digiline:getAnyOutputRules(output)
-	local inputrules  = digiline:getAnyInputRules (input)
+function digilines:rules_link(output, input)
+	local outputrules = digilines:getAnyOutputRules(output)
+	local inputrules  = digilines:getAnyInputRules (input)
 
 	if not outputrules or not inputrules then return false end
 
 
 	for _, orule in ipairs(outputrules) do
-		if digiline:cmpPos(digiline:addPosRule(output, orule), input) then
+		if digilines:cmpPos(digilines:addPosRule(output, orule), input) then
 			for _, irule in ipairs(inputrules) do
-				if digiline:cmpPos(digiline:addPosRule(input, irule), output) then
+				if digilines:cmpPos(digilines:addPosRule(input, irule), output) then
 					return true
 				end
 			end
@@ -58,9 +58,9 @@ function digiline:rules_link(output, input)
 	return false
 end
 
-function digiline:rules_link_anydir(output, input)
-	return digiline:rules_link(output, input)
-	or     digiline:rules_link(input, output)
+function digilines:rules_link_anydir(output, input)
+	return digilines:rules_link(output, input)
+	or     digilines:rules_link(input, output)
 end
 
 local function queue_new()

--- a/internal.lua
+++ b/internal.lua
@@ -1,9 +1,9 @@
-function digilines:getspec(node)
+function digilines.getspec(node)
 	if not minetest.registered_nodes[node.name] then return false end
 	return minetest.registered_nodes[node.name].digiline
 end
 
-function digilines:importrules(spec, node)
+function digilines.importrules(spec, node)
 	if type(spec) == 'function' then
 		return spec(node)
 	elseif spec then
@@ -13,43 +13,43 @@ function digilines:importrules(spec, node)
 	end
 end
 
-function digiline:getAnyInputRules(pos)
-	local node = digiline:get_node_force(pos)
-	local spec = digiline:getspec(node)
+function digilines.getAnyInputRules(pos)
+	local node = digilines.get_node_force(pos)
+	local spec = digilines.getspec(node)
 	if not spec then return end
 
 	if spec.wire then
-		return digilines:importrules(spec.wire.rules, node)
+		return digilines.importrules(spec.wire.rules, node)
 	end
 	if spec.effector then
-		return digilines:importrules(spec.effector.rules, node)
+		return digilines.importrules(spec.effector.rules, node)
 	end
 end
 
-function digiline:getAnyOutputRules(pos)
-	local node = digiline:get_node_force(pos)
-	local spec = digiline:getspec(node)
+function digilines.getAnyOutputRules(pos)
+	local node = digilines.get_node_force(pos)
+	local spec = digilines.getspec(node)
 	if not spec then return end
 
 	if spec.wire then
-		return digilines:importrules(spec.wire.rules, node)
+		return digilines.importrules(spec.wire.rules, node)
 	end
 	if spec.receptor then
-		return digilines:importrules(spec.receptor.rules, node)
+		return digilines.importrules(spec.receptor.rules, node)
 	end
 end
 
-function digilines:rules_link(output, input)
-	local outputrules = digilines:getAnyOutputRules(output)
-	local inputrules  = digilines:getAnyInputRules (input)
+function digilines.rules_link(output, input)
+	local outputrules = digilines.getAnyOutputRules(output)
+	local inputrules  = digilines.getAnyInputRules (input)
 
 	if not outputrules or not inputrules then return false end
 
 
 	for _, orule in ipairs(outputrules) do
-		if digilines:cmpPos(digilines:addPosRule(output, orule), input) then
+		if digilines.cmpPos(digilines.addPosRule(output, orule), input) then
 			for _, irule in ipairs(inputrules) do
-				if digilines:cmpPos(digilines:addPosRule(input, irule), output) then
+				if digilines.cmpPos(digilines.addPosRule(input, irule), output) then
 					return true
 				end
 			end
@@ -58,9 +58,9 @@ function digilines:rules_link(output, input)
 	return false
 end
 
-function digilines:rules_link_anydir(output, input)
-	return digilines:rules_link(output, input)
-	or     digilines:rules_link(input, output)
+function digilines.rules_link_anydir(output, input)
+	return digilines.rules_link(output, input)
+	or     digilines.rules_link(input, output)
 end
 
 local function queue_new()
@@ -85,14 +85,14 @@ local function queue_dequeue(queue)
 	return object
 end
 
-function digiline:transmit(pos, channel, msg, checked)
-	digiline:vm_begin()
+function digilines.transmit(pos, channel, msg, checked)
+	digilines.vm_begin()
 	local queue = queue_new()
 	queue_enqueue(queue, pos)
 	while not queue_empty(queue) do
 		local curPos = queue_dequeue(queue)
-		local node = digiline:get_node_force(curPos)
-		local spec = digiline:getspec(node)
+		local node = digilines.get_node_force(curPos)
+		local spec = digilines.getspec(node)
 		if spec then
 			-- Effector actions --> Receive
 			if spec.effector then
@@ -101,10 +101,10 @@ function digiline:transmit(pos, channel, msg, checked)
 
 			-- Cable actions --> Transmit
 			if spec.wire then
-				local rules = digiline:importrules(spec.wire.rules, node)
+				local rules = digilines.importrules(spec.wire.rules, node)
 				for _, rule in ipairs(rules) do
-					local nextPos = digiline:addPosRule(curPos, rule)
-					if digiline:rules_link(curPos, nextPos) then
+					local nextPos = digilines.addPosRule(curPos, rule)
+					if digilines.rules_link(curPos, nextPos) then
 						local checkedID = minetest.hash_node_position(nextPos)
 						if not checked[checkedID] then
 							checked[checkedID] = true
@@ -115,5 +115,5 @@ function digiline:transmit(pos, channel, msg, checked)
 			end
 		end
 	end
-	digiline:vm_end()
+	digilines.vm_end()
 end

--- a/inventory.lua
+++ b/inventory.lua
@@ -2,7 +2,7 @@ local function sendMessage(pos, msg, channel)
 	if channel == nil then
 		channel = minetest.get_meta(pos):get_string("channel")
 	end
-	digiline:receptor_send(pos,digiline.rules.default,channel,msg)
+	digilines:receptor_send(pos,digilines.rules.default,channel,msg)
 end
 
 local function maybeString(stack)

--- a/inventory.lua
+++ b/inventory.lua
@@ -58,10 +58,10 @@ minetest.register_node("digilines:chest", {
 	end,
 	after_place_node = tubescan,
 	after_dig_node = tubescan,
-	can_dig = function(pos, player)
+	can_dig = function(pos)
 		return minetest.get_meta(pos):get_inventory():is_empty("main")
 	end,
-	on_receive_fields = function(pos, formname, fields, sender)
+	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
 			minetest.record_protection_violation(pos, name)
@@ -74,7 +74,7 @@ minetest.register_node("digilines:chest", {
 	digiline = {
 		receptor = {},
 		effector = {
-			action = function(pos,node,channel,msg) end
+			action = function() end
 		}
 	},
 	tube = {
@@ -83,10 +83,10 @@ minetest.register_node("digilines:chest", {
 			return not pipeworks.connects.facingFront(i,param2)
 		end,
 		input_inventory = "main",
-		can_insert = function(pos, node, stack, direction)
+		can_insert = function(pos, _, stack)
 			return can_insert(pos, stack)
 		end,
-		insert_object = function(pos, node, stack, direction)
+		insert_object = function(pos, _, stack)
 			local inv = minetest.get_meta(pos):get_inventory()
 			local leftover = inv:add_item("main", stack)
 			local count = leftover:get_count()
@@ -108,16 +108,16 @@ minetest.register_node("digilines:chest", {
 			return leftover
 		end,
 	},
-	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
+	allow_metadata_inventory_put = function(pos, _, _, stack)
 		if not can_insert(pos, stack) then
 			sendMessage(pos,"uoverflow "..maybeString(stack))
 		end
 		return stack:get_count()
 	end,
-	on_metadata_inventory_move = function(pos, fromlistname, fromindex, tolistname, toindex, count, player)
+	on_metadata_inventory_move = function(pos, _, _, _, _, _, player)
 		minetest.log("action", player:get_player_name().." moves stuff in chest at "..minetest.pos_to_string(pos))
 	end,
-	on_metadata_inventory_put = function(pos, listname, index, stack, player)
+	on_metadata_inventory_put = function(pos, _, _, stack, player)
 		local channel = minetest.get_meta(pos):get_string("channel")
 		local send = function(msg)
 			sendMessage(pos,msg,channel)
@@ -132,7 +132,7 @@ minetest.register_node("digilines:chest", {
 		end
 		minetest.log("action", player:get_player_name().." puts stuff into chest at "..minetest.pos_to_string(pos))
 	end,
-	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+	on_metadata_inventory_take = function(pos, listname, _, stack, player)
 		local meta = minetest.get_meta(pos)
 		local channel = meta:get_string("channel")
 		local inv = meta:get_inventory()

--- a/inventory.lua
+++ b/inventory.lua
@@ -2,7 +2,7 @@ local function sendMessage(pos, msg, channel)
 	if channel == nil then
 		channel = minetest.get_meta(pos):get_string("channel")
 	end
-	digilines:receptor_send(pos,digilines.rules.default,channel,msg)
+	digilines.receptor_send(pos,digilines.rules.default,channel,msg)
 end
 
 local function maybeString(stack)

--- a/lcd.lua
+++ b/lcd.lua
@@ -20,6 +20,88 @@ else
 	end
 end
 
+-- CONSTANTS
+local LCD_WITH = 100
+local LCD_PADDING = 8
+
+local LINE_LENGTH = 12
+local NUMBER_OF_LINES = 5
+
+local LINE_HEIGHT = 14
+local CHAR_WIDTH = 5
+
+local create_lines = function(text)
+	local line = ""
+	local line_num = 1
+	local tab = {}
+	for word in string.gmatch(text, "%S+") do
+		if string.len(line)+string.len(word) < LINE_LENGTH and word ~= "|" then
+			if line ~= "" then
+				line = line.." "..word
+			else
+				line = word
+			end
+		else
+			table.insert(tab, line)
+			if word ~= "|" then
+				line = word
+			else
+				line = ""
+			end
+			line_num = line_num+1
+			if line_num > NUMBER_OF_LINES then
+				return tab
+			end
+		end
+	end
+	table.insert(tab, line)
+	return tab
+end
+
+local generate_line = function(s, ypos)
+	local i = 1
+	local parsed = {}
+	local width = 0
+	local chars = 0
+	while chars < max_chars and i <= #s do
+		local file = nil
+		if charmap[s:sub(i, i)] ~= nil then
+			file = charmap[s:sub(i, i)]
+			i = i + 1
+		elseif i < #s and charmap[s:sub(i, i + 1)] ~= nil then
+			file = charmap[s:sub(i, i + 1)]
+			i = i + 2
+		else
+			print("[digilines] W: LCD: unknown symbol in '"..s.."' at "..i)
+			i = i + 1
+		end
+		if file ~= nil then
+			width = width + CHAR_WIDTH
+			table.insert(parsed, file)
+			chars = chars + 1
+		end
+	end
+	width = width - 1
+
+	local texture = ""
+	local xpos = math.floor((LCD_WITH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
+	for ii = 1, #parsed do
+		texture = texture..":"..xpos..","..ypos.."="..parsed[ii]..".png"
+		xpos = xpos + CHAR_WIDTH + 1
+	end
+	return texture
+end
+
+local generate_texture = function(lines)
+	local texture = "[combine:"..LCD_WITH.."x"..LCD_WITH
+	local ypos = 16
+	for i = 1, #lines do
+		texture = texture..generate_line(lines[i], ypos)
+		ypos = ypos + LINE_HEIGHT
+	end
+	return texture
+end
+
 local lcds = {
 	-- on ceiling
 	--* [0] = {delta = {x = 0, y = 0.4, z = 0}, pitch = math.pi / -2},
@@ -118,7 +200,7 @@ minetest.register_node("digilines:lcd", {
 		end
 	end,
 
-	digiline = 
+	digiline =
 	{
 		receptor = {},
 		effector = {
@@ -140,88 +222,6 @@ minetest.register_entity(":digilines_lcd:text", {
 		self.object:set_properties({textures={generate_texture(create_lines(text))}})
 	end
 })
-
--- CONSTANTS
-local LCD_WITH = 100
-local LCD_PADDING = 8
-
-local LINE_LENGTH = 12
-local NUMBER_OF_LINES = 5
-
-local LINE_HEIGHT = 14
-local CHAR_WIDTH = 5
-
-create_lines = function(text)
-	local line = ""
-	local line_num = 1
-	local tab = {}
-	for word in string.gmatch(text, "%S+") do
-		if string.len(line)+string.len(word) < LINE_LENGTH and word ~= "|" then
-			if line ~= "" then
-				line = line.." "..word
-			else
-				line = word
-			end
-		else
-			table.insert(tab, line)
-			if word ~= "|" then
-				line = word
-			else
-				line = ""
-			end
-			line_num = line_num+1
-			if line_num > NUMBER_OF_LINES then
-				return tab
-			end
-		end
-	end
-	table.insert(tab, line)
-	return tab
-end
-
-generate_texture = function(lines)
-	local texture = "[combine:"..LCD_WITH.."x"..LCD_WITH
-	local ypos = 16
-	for i = 1, #lines do
-		texture = texture..generate_line(lines[i], ypos)
-		ypos = ypos + LINE_HEIGHT
-	end
-	return texture
-end
-
-generate_line = function(s, ypos)
-	local i = 1
-	local parsed = {}
-	local width = 0
-	local chars = 0
-	while chars < max_chars and i <= #s do
-		local file = nil
-		if charmap[s:sub(i, i)] ~= nil then
-			file = charmap[s:sub(i, i)]
-			i = i + 1
-		elseif i < #s and charmap[s:sub(i, i + 1)] ~= nil then
-			file = charmap[s:sub(i, i + 1)]
-			i = i + 2
-		else
-			print("[digilines] W: LCD: unknown symbol in '"..s.."' at "..i)
-			i = i + 1
-		end
-		if file ~= nil then
-			width = width + CHAR_WIDTH
-			table.insert(parsed, file)
-			chars = chars + 1
-		end
-	end
-	width = width - 1
-
-	local texture = ""
-	local xpos = math.floor((LCD_WITH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
-	for i = 1, #parsed do
-		texture = texture..":"..xpos..","..ypos.."="..parsed[i]..".png"
-		xpos = xpos + CHAR_WIDTH + 1
-	end
-	return texture
-end
 
 minetest.register_craft({
 	output = "digilines:lcd 2",

--- a/lcd.lua
+++ b/lcd.lua
@@ -140,7 +140,7 @@ local prepare_writing = function(pos)
 	return text
 end
 
-local on_digiline_receive = function(pos, node, channel, msg)
+local on_digiline_receive = function(pos, _, channel, msg)
 	local meta = minetest.get_meta(pos)
 	local setchan = meta:get_string("channel")
 	if setchan ~= channel then return end
@@ -173,7 +173,7 @@ minetest.register_node("digilines:lcd", {
 	selection_box = lcd_box,
 	groups = {choppy = 3, dig_immediate = 2},
 
-	after_place_node = function (pos, placer, itemstack)
+	after_place_node = function (pos)
 		local param2 = minetest.get_node(pos).param2
 		if param2 == 0 or param2 == 1 then
 			minetest.add_node(pos, {name = "digilines:lcd", param2 = 3})
@@ -189,7 +189,7 @@ minetest.register_node("digilines:lcd", {
 		clearscreen(pos)
 	end,
 
-	on_receive_fields = function(pos, formname, fields, sender)
+	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
 			minetest.record_protection_violation(pos, name)

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -39,7 +39,7 @@ minetest.register_node("digilines:lightsensor", {
 	groups = {dig_immediate=2},
 	selection_box = lsensor_selbox,
 	node_box = lsensor_nodebox,
-	digiline = 
+	digiline =
 	{
 		receptor = {},
 		effector = {

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -21,7 +21,7 @@ local lsensor_selbox =
 	fixed = {{ -8/16, -8/16, -8/16, 8/16, -3/16, 8/16 }}
 }
 
-local on_digiline_receive = function (pos, node, channel, msg)
+local on_digiline_receive = function (pos, _, channel, msg)
 	local setchan = minetest.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
 		local lightval = minetest.get_node_light(pos)
@@ -50,7 +50,7 @@ minetest.register_node("digilines:lightsensor", {
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", "field[channel;Channel;${channel}]")
 	end,
-	on_receive_fields = function(pos, formname, fields, sender)
+	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
 			minetest.record_protection_violation(pos, name)

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -25,7 +25,7 @@ local on_digiline_receive = function (pos, node, channel, msg)
 	local setchan = minetest.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
 		local lightval = minetest.get_node_light(pos)
-		digiline:receptor_send(pos, digiline.rules.default, channel, lightval)
+		digilines:receptor_send(pos, digilines.rules.default, channel, lightval)
 	end
 end
 

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -25,7 +25,7 @@ local on_digiline_receive = function (pos, node, channel, msg)
 	local setchan = minetest.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
 		local lightval = minetest.get_node_light(pos)
-		digilines:receptor_send(pos, digilines.rules.default, channel, lightval)
+		digilines.receptor_send(pos, digilines.rules.default, channel, lightval)
 	end
 end
 

--- a/presetrules.lua
+++ b/presetrules.lua
@@ -1,6 +1,6 @@
 digilines.rules = {}
 
-digilines.rules.default = 
+digilines.rules.default =
 {{x=0,  y=0,  z=-1},
 {x=1,  y=0,  z=0},
 {x=-1, y=0,  z=0},

--- a/presetrules.lua
+++ b/presetrules.lua
@@ -1,6 +1,6 @@
-digiline.rules = {}
+digilines.rules = {}
 
-digiline.rules.default = 
+digilines.rules.default = 
 {{x=0,  y=0,  z=-1},
 {x=1,  y=0,  z=0},
 {x=-1, y=0,  z=0},

--- a/rtc.lua
+++ b/rtc.lua
@@ -20,7 +20,7 @@ local on_digiline_receive = function (pos, node, channel, msg)
 	local setchan = minetest.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
 		local timeofday = minetest.get_timeofday()
-		digiline:receptor_send(pos, digiline.rules.default, channel, timeofday)
+		digilines:receptor_send(pos, digilines.rules.default, channel, timeofday)
 	end
 end
 

--- a/rtc.lua
+++ b/rtc.lua
@@ -20,7 +20,7 @@ local on_digiline_receive = function (pos, node, channel, msg)
 	local setchan = minetest.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
 		local timeofday = minetest.get_timeofday()
-		digilines:receptor_send(pos, digilines.rules.default, channel, timeofday)
+		digilines.receptor_send(pos, digilines.rules.default, channel, timeofday)
 	end
 end
 

--- a/rtc.lua
+++ b/rtc.lua
@@ -16,7 +16,7 @@ local rtc_selbox =
 	fixed = {{ -8/16, -8/16, -8/16, 8/16, -3/16, 8/16 }}
 }
 
-local on_digiline_receive = function (pos, node, channel, msg)
+local on_digiline_receive = function (pos, _, channel, msg)
 	local setchan = minetest.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
 		local timeofday = minetest.get_timeofday()
@@ -46,7 +46,7 @@ minetest.register_node("digilines:rtc", {
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", "field[channel;Channel;${channel}]")
 	end,
-	on_receive_fields = function(pos, formname, fields, sender)
+	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
 			minetest.record_protection_violation(pos, name)

--- a/rtc.lua
+++ b/rtc.lua
@@ -35,7 +35,7 @@ minetest.register_node("digilines:rtc", {
 	groups = {dig_immediate=2},
 	selection_box = rtc_selbox,
 	node_box = rtc_nodebox,
-	digiline = 
+	digiline =
 	{
 		receptor = {},
 		effector = {

--- a/util.lua
+++ b/util.lua
@@ -22,9 +22,9 @@ function digilines.rotate_rules_left(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
-		nr[i].z=-rules[i].x
-		nr[i].x=rules[i].z
-		nr[i].y=rules[i].y
+		nr[i].z=-rule.x
+		nr[i].x=rule.z
+		nr[i].y=rule.y
 	end
 	return nr
 end

--- a/util.lua
+++ b/util.lua
@@ -1,13 +1,13 @@
-function digiline:addPosRule(p, r)
+function digilines:addPosRule(p, r)
 	return {x = p.x + r.x, y = p.y + r.y, z = p.z + r.z}
 end
 
-function digiline:cmpPos(p1, p2)
+function digilines:cmpPos(p1, p2)
 	return (p1.x == p2.x and p1.y == p2.y and p1.z == p2.z)
 end
 
 --Rules rotation Functions:
-function digiline:rotate_rules_right(rules)
+function digilines:rotate_rules_right(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -18,7 +18,7 @@ function digiline:rotate_rules_right(rules)
 	return nr
 end
 
-function digiline:rotate_rules_left(rules)
+function digilines:rotate_rules_left(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -29,7 +29,7 @@ function digiline:rotate_rules_left(rules)
 	return nr
 end
 
-function digiline:rotate_rules_down(rules)
+function digilines:rotate_rules_down(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -40,7 +40,7 @@ function digiline:rotate_rules_down(rules)
 	return nr
 end
 
-function digiline:rotate_rules_up(rules)
+function digilines:rotate_rules_up(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -51,13 +51,13 @@ function digiline:rotate_rules_up(rules)
 	return nr
 end
 
-function digiline:tablecopy(table) -- deep table copy
+function digilines:tablecopy(table) -- deep table copy
 	if type(table) ~= "table" then return table end -- no need to copy
 	local newtable = {}
 
 	for idx, item in pairs(table) do
 		if type(item) == "table" then
-			newtable[idx] = digiline:tablecopy(item)
+			newtable[idx] = digilines:tablecopy(item)
 		else
 			newtable[idx] = item
 		end

--- a/util.lua
+++ b/util.lua
@@ -1,13 +1,13 @@
-function digilines:addPosRule(p, r)
+function digilines.addPosRule(p, r)
 	return {x = p.x + r.x, y = p.y + r.y, z = p.z + r.z}
 end
 
-function digilines:cmpPos(p1, p2)
+function digilines.cmpPos(p1, p2)
 	return (p1.x == p2.x and p1.y == p2.y and p1.z == p2.z)
 end
 
 --Rules rotation Functions:
-function digilines:rotate_rules_right(rules)
+function digilines.rotate_rules_right(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -18,7 +18,7 @@ function digilines:rotate_rules_right(rules)
 	return nr
 end
 
-function digilines:rotate_rules_left(rules)
+function digilines.rotate_rules_left(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -29,7 +29,7 @@ function digilines:rotate_rules_left(rules)
 	return nr
 end
 
-function digilines:rotate_rules_down(rules)
+function digilines.rotate_rules_down(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -40,7 +40,7 @@ function digilines:rotate_rules_down(rules)
 	return nr
 end
 
-function digilines:rotate_rules_up(rules)
+function digilines.rotate_rules_up(rules)
 	local nr={}
 	for i, rule in ipairs(rules) do
 		nr[i]={}
@@ -51,13 +51,13 @@ function digilines:rotate_rules_up(rules)
 	return nr
 end
 
-function digilines:tablecopy(table) -- deep table copy
+function digilines.tablecopy(table) -- deep table copy
 	if type(table) ~= "table" then return table end -- no need to copy
 	local newtable = {}
 
 	for idx, item in pairs(table) do
 		if type(item) == "table" then
-			newtable[idx] = digilines:tablecopy(item)
+			newtable[idx] = digilines.tablecopy(item)
 		else
 			newtable[idx] = item
 		end
@@ -88,12 +88,12 @@ local vm_cache = nil
 -- directly on VM-loaded arrays, which should be faster for reading many nodes
 -- in rapid succession. However, the cache must be flushed with vm_end once the
 -- scan is finished, to avoid using stale data in future.
-function digiline:vm_begin()
+function digilines.vm_begin()
 	vm_cache = {}
 end
 
 -- Ends a bulk-VoxelManipulator operation, freeing the cached data.
-function digiline:vm_end()
+function digilines.vm_end()
 	vm_cache = nil
 end
 
@@ -141,7 +141,7 @@ end
 -- there.
 --
 -- Inside a bulk-VoxelManipulator operation, the operation’s VM cache is used.
-function digiline:get_node_force(pos)
+function digilines.get_node_force(pos)
 	if vm_cache then
 		return vm_get_node(pos)
 	end

--- a/wire_std.lua
+++ b/wire_std.lua
@@ -3,19 +3,19 @@
 -- 1 = there is one; 0 = there is none
 -- y always means y+
 
-box_center = {-1/16, -.5, -1/16, 1/16, -.5+1/16, 1/16}
-box_bump1 =  { -2/16, -8/16,  -2/16, 2/16, -13/32, 2/16 }
-box_bump2 =  { -3/32, -13/32, -3/32, 3/32, -12/32, 3/32 }
+local box_center = {-1/16, -.5, -1/16, 1/16, -.5+1/16, 1/16}
+local box_bump1 =  { -2/16, -8/16,  -2/16, 2/16, -13/32, 2/16 }
+local box_bump2 =  { -3/32, -13/32, -3/32, 3/32, -12/32, 3/32 }
 
-box_xp = {1/16, -.5, -1/16, 8/16, -.5+1/16, 1/16}
-box_zp = {-1/16, -.5, 1/16, 1/16, -.5+1/16, 8/16}
-box_xm = {-8/16, -.5, -1/16, -1/16, -.5+1/16, 1/16}
-box_zm = {-1/16, -.5, -8/16, 1/16, -.5+1/16, -1/16}
+local box_xp = {1/16, -.5, -1/16, 8/16, -.5+1/16, 1/16}
+local box_zp = {-1/16, -.5, 1/16, 1/16, -.5+1/16, 8/16}
+local box_xm = {-8/16, -.5, -1/16, -1/16, -.5+1/16, 1/16}
+local box_zm = {-1/16, -.5, -8/16, 1/16, -.5+1/16, -1/16}
 
-box_xpy = {.5-1/16, -.5+1/16, -1/16, .5, .4999+1/16, 1/16}
-box_zpy = {-1/16, -.5+1/16, .5-1/16, 1/16, .4999+1/16, .5}
-box_xmy = {-.5, -.5+1/16, -1/16, -.5+1/16, .4999+1/16, 1/16}
-box_zmy = {-1/16, -.5+1/16, -.5, 1/16, .4999+1/16, -.5+1/16}
+local box_xpy = {.5-1/16, -.5+1/16, -1/16, .5, .4999+1/16, 1/16}
+local box_zpy = {-1/16, -.5+1/16, .5-1/16, 1/16, .4999+1/16, .5}
+local box_xmy = {-.5, -.5+1/16, -1/16, -.5+1/16, .4999+1/16, 1/16}
+local box_zmy = {-1/16, -.5+1/16, -.5, 1/16, .4999+1/16, -.5+1/16}
 
 for xp=0, 1 do
 for zp=0, 1 do
@@ -25,12 +25,14 @@ for xpy=0, 1 do
 for zpy=0, 1 do
 for xmy=0, 1 do
 for zmy=0, 1 do
-	if (xpy == 1 and xp == 0) or (zpy == 1 and zp == 0) 
+	if (xpy == 1 and xp == 0) or (zpy == 1 and zp == 0)
 	or (xmy == 1 and xm == 0) or (zmy == 1 and zm == 0) then break end
 
 	local groups
 	local nodeid = 	tostring(xp )..tostring(zp )..tostring(xm )..tostring(zm )..
 			tostring(xpy)..tostring(zpy)..tostring(xmy)..tostring(zmy)
+
+	local wiredesc
 
 	if nodeid == "00000000" then
 		groups = {dig_immediate = 3}
@@ -51,6 +53,7 @@ for zmy=0, 1 do
 	if xmy == 1 then table.insert(nodebox, box_xmy) end
 	if zmy == 1 then table.insert(nodebox, box_zmy) end
 
+	local tiles
 	if adjx and adjz and (xp + zp + xm + zm > 2) then
 		table.insert(nodebox, box_bump1)
 		table.insert(nodebox, box_bump2)
@@ -87,16 +90,16 @@ for zmy=0, 1 do
 		paramtype = "light",
 		paramtype2 = "facedir",
 		sunlight_propagates = true,
-		digiline = 
+		digiline =
 		{
-			wire = 
+			wire =
 			{
 				basename = "digilines:wire_std_",
 				use_autoconnect = true
 			}
 		},
 		selection_box = {
-              	type = "fixed",
+			type = "fixed",
 			fixed = {-.5, -.5, -.5, .5, -.5+1/16, .5}
 		},
 		node_box = {

--- a/wires_common.lua
+++ b/wires_common.lua
@@ -1,17 +1,17 @@
 minetest.register_on_placenode(function(pos, node)
 	if minetest.registered_nodes[node.name].digiline then
-		digiline:update_autoconnect(pos)
+		digilines:update_autoconnect(pos)
 	end
 end)
 
 minetest.register_on_dignode(function(pos, node)
 	if minetest.registered_nodes[node.name] and minetest.registered_nodes[node.name].digiline then
 -- need to make sure that node exists (unknown nodes!)
-		digiline:update_autoconnect(pos)
+		digilines:update_autoconnect(pos)
 	end
 end)
 
-function digiline:update_autoconnect(pos, secondcall)
+function digilines:update_autoconnect(pos, secondcall)
 	local xppos = {x=pos.x+1, y=pos.y, z=pos.z}
 	local zppos = {x=pos.x, y=pos.y, z=pos.z+1}
 	local xmpos = {x=pos.x-1, y=pos.y, z=pos.z}
@@ -26,20 +26,20 @@ function digiline:update_autoconnect(pos, secondcall)
 	local zmypos = {x=pos.x, y=pos.y+1, z=pos.z-1}
 
 	if secondcall == nil then
-		digiline:update_autoconnect(xppos, true)
-		digiline:update_autoconnect(zppos, true)
-		digiline:update_autoconnect(xmpos, true)
-		digiline:update_autoconnect(zmpos, true)
+		digilines:update_autoconnect(xppos, true)
+		digilines:update_autoconnect(zppos, true)
+		digilines:update_autoconnect(xmpos, true)
+		digilines:update_autoconnect(zmpos, true)
 
-		digiline:update_autoconnect(xpypos, true)
-		digiline:update_autoconnect(zpypos, true)
-		digiline:update_autoconnect(xmypos, true)
-		digiline:update_autoconnect(zmypos, true)
+		digilines:update_autoconnect(xpypos, true)
+		digilines:update_autoconnect(zpypos, true)
+		digilines:update_autoconnect(xmypos, true)
+		digilines:update_autoconnect(zmypos, true)
 
-		digiline:update_autoconnect(xpympos, true)
-		digiline:update_autoconnect(zpympos, true)
-		digiline:update_autoconnect(xmympos, true)
-		digiline:update_autoconnect(zmympos, true)
+		digilines:update_autoconnect(xpympos, true)
+		digilines:update_autoconnect(zpympos, true)
+		digilines:update_autoconnect(xmympos, true)
+		digilines:update_autoconnect(zmympos, true)
 	end
 
 	local def = minetest.registered_nodes[minetest.get_node(pos).name]
@@ -49,20 +49,20 @@ function digiline:update_autoconnect(pos, secondcall)
 		return nil
 	end
 
-	local zmg = 	digiline:rules_link_anydir(pos, zmpos)
-	local zmymg = 	digiline:rules_link_anydir(pos, zmympos)
-	local xmg = 	digiline:rules_link_anydir(pos, xmpos)
-	local xmymg = 	digiline:rules_link_anydir(pos, xmympos)
-	local zpg = 	digiline:rules_link_anydir(pos, zppos)
-	local zpymg = 	digiline:rules_link_anydir(pos, zpympos)
-	local xpg = 	digiline:rules_link_anydir(pos, xppos)
-	local xpymg = 	digiline:rules_link_anydir(pos, xpympos)
+	local zmg = 	digilines:rules_link_anydir(pos, zmpos)
+	local zmymg = 	digilines:rules_link_anydir(pos, zmympos)
+	local xmg = 	digilines:rules_link_anydir(pos, xmpos)
+	local xmymg = 	digilines:rules_link_anydir(pos, xmympos)
+	local zpg = 	digilines:rules_link_anydir(pos, zppos)
+	local zpymg = 	digilines:rules_link_anydir(pos, zpympos)
+	local xpg = 	digilines:rules_link_anydir(pos, xppos)
+	local xpymg = 	digilines:rules_link_anydir(pos, xpympos)
 
 
-	local xpyg = digiline:rules_link_anydir(pos, xpypos)
-	local zpyg = digiline:rules_link_anydir(pos, zpypos)
-	local xmyg = digiline:rules_link_anydir(pos, xmypos)
-	local zmyg = digiline:rules_link_anydir(pos, zmypos)
+	local xpyg = digilines:rules_link_anydir(pos, xpypos)
+	local zpyg = digilines:rules_link_anydir(pos, zpypos)
+	local xmyg = digilines:rules_link_anydir(pos, xmypos)
+	local zmyg = digilines:rules_link_anydir(pos, zmypos)
 
 	local zm, xm, zp, xp, xpy, zpy, xmy, zmy
 	if zmg or zmymg then zm = 1 else zm = 0 end

--- a/wires_common.lua
+++ b/wires_common.lua
@@ -1,17 +1,17 @@
 minetest.register_on_placenode(function(pos, node)
 	if minetest.registered_nodes[node.name].digiline then
-		digilines:update_autoconnect(pos)
+		digilines.update_autoconnect(pos)
 	end
 end)
 
 minetest.register_on_dignode(function(pos, node)
 	if minetest.registered_nodes[node.name] and minetest.registered_nodes[node.name].digiline then
 -- need to make sure that node exists (unknown nodes!)
-		digilines:update_autoconnect(pos)
+		digilines.update_autoconnect(pos)
 	end
 end)
 
-function digilines:update_autoconnect(pos, secondcall)
+function digilines.update_autoconnect(pos, secondcall)
 	local xppos = {x=pos.x+1, y=pos.y, z=pos.z}
 	local zppos = {x=pos.x, y=pos.y, z=pos.z+1}
 	local xmpos = {x=pos.x-1, y=pos.y, z=pos.z}
@@ -26,20 +26,20 @@ function digilines:update_autoconnect(pos, secondcall)
 	local zmypos = {x=pos.x, y=pos.y+1, z=pos.z-1}
 
 	if secondcall == nil then
-		digilines:update_autoconnect(xppos, true)
-		digilines:update_autoconnect(zppos, true)
-		digilines:update_autoconnect(xmpos, true)
-		digilines:update_autoconnect(zmpos, true)
+		digilines.update_autoconnect(xppos, true)
+		digilines.update_autoconnect(zppos, true)
+		digilines.update_autoconnect(xmpos, true)
+		digilines.update_autoconnect(zmpos, true)
 
-		digilines:update_autoconnect(xpypos, true)
-		digilines:update_autoconnect(zpypos, true)
-		digilines:update_autoconnect(xmypos, true)
-		digilines:update_autoconnect(zmypos, true)
+		digilines.update_autoconnect(xpypos, true)
+		digilines.update_autoconnect(zpypos, true)
+		digilines.update_autoconnect(xmypos, true)
+		digilines.update_autoconnect(zmypos, true)
 
-		digilines:update_autoconnect(xpympos, true)
-		digilines:update_autoconnect(zpympos, true)
-		digilines:update_autoconnect(xmympos, true)
-		digilines:update_autoconnect(zmympos, true)
+		digilines.update_autoconnect(xpympos, true)
+		digilines.update_autoconnect(zpympos, true)
+		digilines.update_autoconnect(xmympos, true)
+		digilines.update_autoconnect(zmympos, true)
 	end
 
 	local def = minetest.registered_nodes[minetest.get_node(pos).name]
@@ -49,20 +49,20 @@ function digilines:update_autoconnect(pos, secondcall)
 		return nil
 	end
 
-	local zmg = 	digilines:rules_link_anydir(pos, zmpos)
-	local zmymg = 	digilines:rules_link_anydir(pos, zmympos)
-	local xmg = 	digilines:rules_link_anydir(pos, xmpos)
-	local xmymg = 	digilines:rules_link_anydir(pos, xmympos)
-	local zpg = 	digilines:rules_link_anydir(pos, zppos)
-	local zpymg = 	digilines:rules_link_anydir(pos, zpympos)
-	local xpg = 	digilines:rules_link_anydir(pos, xppos)
-	local xpymg = 	digilines:rules_link_anydir(pos, xpympos)
+	local zmg = 	digilines.rules_link_anydir(pos, zmpos)
+	local zmymg = 	digilines.rules_link_anydir(pos, zmympos)
+	local xmg = 	digilines.rules_link_anydir(pos, xmpos)
+	local xmymg = 	digilines.rules_link_anydir(pos, xmympos)
+	local zpg = 	digilines.rules_link_anydir(pos, zppos)
+	local zpymg = 	digilines.rules_link_anydir(pos, zpympos)
+	local xpg = 	digilines.rules_link_anydir(pos, xppos)
+	local xpymg = 	digilines.rules_link_anydir(pos, xpympos)
 
 
-	local xpyg = digilines:rules_link_anydir(pos, xpypos)
-	local zpyg = digilines:rules_link_anydir(pos, zpypos)
-	local xmyg = digilines:rules_link_anydir(pos, xmypos)
-	local zmyg = digilines:rules_link_anydir(pos, zmypos)
+	local xpyg = digilines.rules_link_anydir(pos, xpypos)
+	local zpyg = digilines.rules_link_anydir(pos, zpypos)
+	local xmyg = digilines.rules_link_anydir(pos, xmypos)
+	local zmyg = digilines.rules_link_anydir(pos, zmypos)
 
 	local zm, xm, zp, xp, xpy, zpy, xmy, zmy
 	if zmg or zmymg then zm = 1 else zm = 0 end


### PR DESCRIPTION
Renames the global `digiline` to `digilines`, keeping `digiline` as an alias for backwards compatibility, localizes globals, and fixes whitespace errors (inconsistent indentation and trailing whitespace).
