### PR TITLE
Fix duplicate messages

### DIFF
--- a/internal.lua
+++ b/internal.lua
@@ -86,6 +86,12 @@ local function queue_dequeue(queue)
 end
 
 function digilines.transmit(pos, channel, msg, checked)
+	local checkedID = minetest.hash_node_position(pos)
+	if checked[checkedID] then
+		return
+	end
+	checked[checkedID]=true
+	
 	digilines.vm_begin()
 	local queue = queue_new()
 	queue_enqueue(queue, pos)

--- a/internal.lua
+++ b/internal.lua
@@ -90,7 +90,7 @@ function digilines.transmit(pos, channel, msg, checked)
 	if checked[checkedID] then
 		return
 	end
-	checked[checkedID]=true
+	checked[checkedID] = true
 	
 	digilines.vm_begin()
 	local queue = queue_new()


### PR DESCRIPTION
The first digiline device was not added to the list of checked nodes, or skipped if it has already been checked. This caused duplicate messages if there are 2 digiline devices right next to each other that are also connected with digiline wires:
![image](https://user-images.githubusercontent.com/4053256/46685243-00f64180-cbc3-11e8-8319-dffc30b67ee8.png)

