### PR TITLE
Fix entity overloading and add missing entity check

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -65,18 +65,18 @@ minetest.register_craft({
 })
 
 -- former submods
-if minetest.is_yes(minetest.setting_get("digilines_enable_inventory") or true) then
+if minetest.is_yes(minetest.settings:get("digilines_enable_inventory") or true) then
 	dofile(modpath .. "/inventory.lua")
 end
 
-if minetest.is_yes(minetest.setting_get("digilines_enable_lcd") or true) then
+if minetest.is_yes(minetest.settings:get("digilines_enable_lcd") or true) then
 	dofile(modpath .. "/lcd.lua")
 end
 
-if minetest.is_yes(minetest.setting_get("digilines_enable_lightsensor") or true) then
+if minetest.is_yes(minetest.settings:get("digilines_enable_lightsensor") or true) then
 	dofile(modpath .. "/lightsensor.lua")
 end
 
-if minetest.is_yes(minetest.setting_get("digilines_enable_rtc") or true) then
+if minetest.is_yes(minetest.settings:get("digilines_enable_rtc") or true) then
 	dofile(modpath .. "/rtc.lua")
 end

--- a/init.lua
+++ b/init.lua
@@ -65,18 +65,18 @@ minetest.register_craft({
 })
 
 -- former submods
-if minetest.is_yes(minetest.settings:get("digilines_enable_inventory") or true) then
+if minetest.is_yes(minetest.setting_get("digilines_enable_inventory") or true) then
 	dofile(modpath .. "/inventory.lua")
 end
 
-if minetest.is_yes(minetest.settings:get("digilines_enable_lcd") or true) then
+if minetest.is_yes(minetest.setting_get("digilines_enable_lcd") or true) then
 	dofile(modpath .. "/lcd.lua")
 end
 
-if minetest.is_yes(minetest.settings:get("digilines_enable_lightsensor") or true) then
+if minetest.is_yes(minetest.setting_get("digilines_enable_lightsensor") or true) then
 	dofile(modpath .. "/lightsensor.lua")
 end
 
-if minetest.is_yes(minetest.settings:get("digilines_enable_rtc") or true) then
+if minetest.is_yes(minetest.setting_get("digilines_enable_rtc") or true) then
 	dofile(modpath .. "/rtc.lua")
 end

--- a/lcd.lua
+++ b/lcd.lua
@@ -163,7 +163,6 @@ local spawn_entity = function(pos)
 		end
 		local text = minetest.add_entity(vector.add(pos, lcd_info.delta), "digilines_lcd:text")
 		text:set_yaw(lcd_info.yaw or 0)
-		return text
 	end
 end
 

--- a/lcd.lua
+++ b/lcd.lua
@@ -119,7 +119,6 @@ local reset_meta = function(pos)
 end
 
 local clearscreen = function(pos)
-	minetest.chat_send_all("clearing screen at "..minetest.pos_to_string(pos))
 	local objects = minetest.get_objects_inside_radius(pos, 0.5)
 	for _, o in ipairs(objects) do
 		local o_entity = o:get_luaentity()

--- a/lcd.lua
+++ b/lcd.lua
@@ -168,8 +168,9 @@ local spawn_entity = function(pos)
 end
 
 local prepare_writing = function(pos)
-	if get_entity(pos) then
-		set_texture(get_entity(pos))
+	local entity = get_entity(pos)
+	if entity then
+		set_texture(entity)
 	end	
 end
 

--- a/lcd.lua
+++ b/lcd.lua
@@ -161,7 +161,7 @@ local on_digiline_receive = function(pos, _, channel, msg)
 
 	meta:set_string("text", msg)
 	meta:set_string("infotext", msg)
-	clearscreen(pos)
+
 	if msg ~= "" then
 		prepare_writing(pos)
 	end

--- a/lcd.lua
+++ b/lcd.lua
@@ -216,7 +216,7 @@ minetest.register_node("digilines:lcd", {
 	on_construct = reset_meta,
 	on_destruct = clearscreen,
 	on_punch = function(pos, node, puncher, pointed_thing)
-		if puncher:is_player() and minetest.get_player_by_name(puncher:get_player_name()) then
+		if minetest.is_player(puncher) then
 			spawn_entity(pos)
 		end
 	end,

--- a/lcd.lua
+++ b/lcd.lua
@@ -170,6 +170,12 @@ local prepare_writing = function(pos)
 	local entity = get_entity(pos)
 	if entity then
 		set_texture(entity)
+		local lcd_info = lcds[minetest.get_node(pos).param2]
+		if not lcd_info then
+			return
+		end
+		entity.object:set_pos(vector.add(pos, lcd_info.delta))
+		entity.object:set_yaw(lcd_info.yaw or 0)
 	end	
 end
 

--- a/lcd.lua
+++ b/lcd.lua
@@ -128,6 +128,12 @@ local clearscreen = function(pos)
 	end
 end
 
+local set_texture = function(ent)
+	local meta = minetest.get_meta(ent.object:getpos())
+	local text = meta:get_string("text")
+	ent.object:set_properties({textures={generate_texture(create_lines(text))}})
+end
+
 local prepare_writing = function(pos)
 	local existing
 	local objects = minetest.get_objects_inside_radius(pos, 0.5)
@@ -138,7 +144,7 @@ local prepare_writing = function(pos)
 			break
 		end
 	end
-	if not existing or existing == nil then
+	if not existing then
 		local lcd_info = lcds[minetest.get_node(pos).param2]
 		if lcd_info == nil then return end
 		local text = minetest.add_entity(
@@ -148,9 +154,7 @@ local prepare_writing = function(pos)
 		text:setyaw(lcd_info.yaw or 0)
 		return text
 	else
-		local meta = minetest.get_meta(existing.object:getpos())
-		local text = meta:get_string("text")
-		existing.object:set_properties({textures={generate_texture(create_lines(text))}})
+		set_texture(existing)
 	end
 end
 
@@ -239,11 +243,7 @@ minetest.register_entity(":digilines_lcd:text", {
 	collisionbox = { 0, 0, 0, 0, 0, 0 },
 	visual = "upright_sprite",
 	textures = {},
-	on_activate = function(self)
-		local meta = minetest.get_meta(self.object:getpos())
-		local text = meta:get_string("text")
-		self.object:set_properties({textures={generate_texture(create_lines(text))}})
-	end
+	on_activate = set_texture,
 })
 
 minetest.register_craft({


### PR DESCRIPTION
This should fix #50.
Changes behavior so now the text entity is only spawned once and edited when changes are needed.
~~If if cant find an existing entity, it adds a new one. This is run __only when the lcd receives an update__.~~ The entity is spawned when the LCD is placed. If a clearobjects is run, the LCD can be punched to add a new entity, other wise the LBM below will take care of it when possible.

Added an LBM to replace missing text (eg. after clearobjects; doesnt require lcd update).