### PR TITLE
lcd panel: increase the offset of the text plane to the nodebox to avoid z-fighting

### DIFF
--- a/lcd.lua
+++ b/lcd.lua
@@ -108,10 +108,10 @@ local lcds = {
 	-- on ground
 	--* [1] = {delta = {x = 0, y =-0.4, z = 0}, pitch = math.pi /  2},
 	-- sides
-	[2] = {delta = {x =  0.437, y = 0, z = 0}, yaw = math.pi / -2},
-	[3] = {delta = {x = -0.437, y = 0, z = 0}, yaw = math.pi /  2},
-	[4] = {delta = {x = 0, y = 0, z =  0.437}, yaw = 0},
-	[5] = {delta = {x = 0, y = 0, z = -0.437}, yaw = math.pi},
+	[2] = {delta = {x =  0.42, y = 0, z = 0}, yaw = math.pi / -2},
+	[3] = {delta = {x = -0.42, y = 0, z = 0}, yaw = math.pi /  2},
+	[4] = {delta = {x = 0, y = 0, z =  0.42}, yaw = 0},
+	[5] = {delta = {x = 0, y = 0, z = -0.42}, yaw = math.pi},
 }
 
 local reset_meta = function(pos)
@@ -173,7 +173,7 @@ local prepare_writing = function(pos)
 	if entity then
 		set_texture(entity)
 		rotate_text(pos)
-	end	
+	end
 end
 
 local spawn_entity = function(pos)


### PR DESCRIPTION
Fixes #56.

Z-fighting is more rare.