### PR TITLE
LCDs: Print fitting lines verbatim, show unknown symbols as spaces

### DIFF
--- a/lcd.lua
+++ b/lcd.lua
@@ -87,7 +87,7 @@ local generate_line = function(s, ypos)
 	width = width - 1
 
 	local texture = ""
-	local xpos = math.floor((LCD_WIDTH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
+	local xpos = math.floor((LCD_WIDTH - 2 * LCD_PADDING - width) / 2)
 	for ii = 1, #parsed do
 		texture = texture..":"..xpos..","..ypos.."="..parsed[ii]..".png"
 		xpos = xpos + CHAR_WIDTH + 1

--- a/lcd.lua
+++ b/lcd.lua
@@ -34,23 +34,27 @@ local create_lines = function(text)
 	local line = ""
 	local line_num = 1
 	local tab = {}
-	for word in string.gmatch(text, "%S+") do
-		if string.len(line)+string.len(word) < LINE_LENGTH and word ~= "|" then
-			if line ~= "" then
-				line = line.." "..word
+	if #text <= LINE_LENGTH then
+		line = text
+	else
+		for word in string.gmatch(text, "%S+") do
+			if string.len(line)+string.len(word) < LINE_LENGTH and word ~= "|" then
+				if line ~= "" then
+					line = line.." "..word
+				else
+					line = word
+				end
 			else
-				line = word
-			end
-		else
-			table.insert(tab, line)
-			if word ~= "|" then
-				line = word
-			else
-				line = ""
-			end
-			line_num = line_num+1
-			if line_num > NUMBER_OF_LINES then
-				return tab
+				table.insert(tab, line)
+				if word ~= "|" then
+					line = word
+				else
+					line = ""
+				end
+				line_num = line_num+1
+				if line_num > NUMBER_OF_LINES then
+					return tab
+				end
 			end
 		end
 	end

--- a/lcd.lua
+++ b/lcd.lua
@@ -73,6 +73,9 @@ local generate_line = function(s, ypos)
 			i = i + 2
 		else
 			print("[digilines] W: LCD: unknown symbol in '"..s.."' at "..i)
+			if charmap[" "] ~= nil then
+				file = charmap[" "]
+			end
 			i = i + 1
 		end
 		if file ~= nil then

--- a/lcd.lua
+++ b/lcd.lua
@@ -21,7 +21,7 @@ else
 end
 
 -- CONSTANTS
-local LCD_WITH = 100
+local LCD_WIDTH = 100
 local LCD_PADDING = 8
 
 local LINE_LENGTH = 12
@@ -87,7 +87,7 @@ local generate_line = function(s, ypos)
 	width = width - 1
 
 	local texture = ""
-	local xpos = math.floor((LCD_WITH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
+	local xpos = math.floor((LCD_WIDTH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
 	for ii = 1, #parsed do
 		texture = texture..":"..xpos..","..ypos.."="..parsed[ii]..".png"
 		xpos = xpos + CHAR_WIDTH + 1
@@ -96,7 +96,7 @@ local generate_line = function(s, ypos)
 end
 
 local generate_texture = function(lines)
-	local texture = "[combine:"..LCD_WITH.."x"..LCD_WITH
+	local texture = "[combine:"..LCD_WIDTH.."x"..LCD_WIDTH
 	local ypos = 16
 	for i = 1, #lines do
 		texture = texture..generate_line(lines[i], ypos)

--- a/lcd.lua
+++ b/lcd.lua
@@ -35,7 +35,9 @@ local create_lines = function(text)
 	local line_num = 1
 	local tab = {}
 	if #text <= LINE_LENGTH then
-		line = text
+		for line in string.gmatch(text, " | ") do
+			table.insert(tab, line)
+		end
 	else
 		for word in string.gmatch(text, "%S+") do
 			if string.len(line)+string.len(word) < LINE_LENGTH and word ~= "|" then


### PR DESCRIPTION
Playing around with LCDs, I got annoyed by the inability to format lines using spaces - consider the following example:

```lua
local width = 12
local tbl = {}

local platform = "Platform 2:"
local line = "[" .. tostring(get_line()) .. "]"
table.insert(platform .. string.rep(" ", width - #platform))
table.insert(string.rep(" ", width - #line) .. line)
digiline_send("lcd", table.join(tbl, " | ")
```

The expected outcome would be something like:

```
Platform 2: 
       [RB5]
```

Instead, the LCD shows:

```
 Platform 2:
    [RB5]   
```

Thus, I propose some changes. I did not change the word break algorithm (yet?), but I changed the line to be used verbatim if it fits on the screen. I'd also propose rendering unknown symbols as spaces instead of just ignoring them. Either of those is sufficient to make my example show the expected behaviour, so if you dislike one of them, I am happy with just one being used.

Furthermore I noticed the display being offset to the right, I found that the padding was incorrectly in the x value calculation and removed it.

***TODO:** Fix linebreaks for lines composed of fewer symbols than the line maximum. Personally I'd prefer to change `\ |\ ` as the identifier to `\n`, but I did not educate myself on the decision process that probably went into this originally.*