### PR TITLE
LCDs: Rework line breaking algorithm, include spaces, show unknown symbols as spaces

### DIFF
--- a/lcd.lua
+++ b/lcd.lua
@@ -32,13 +32,16 @@ local CHAR_WIDTH = 5
 
 local split = function(s, pat)
 	-- adapted from https://stackoverflow.com/a/1647577/4067384
-	pat = pat or '%s+'
-	local st, g = 1, string.gmatch(s, "()("..pat..")")
-	local function getter(segs, seps, sep, cap1, ...)
-		st = sep and seps + #sep
-		return string.sub(s, segs, (seps or 0) - 1), cap1 or sep, ...
+	-- simplified for our only usecase
+	local st, g = 1, s:gmatch("()("..pat..")")
+	local function getter()
+		if st then
+			local segs, seps, sep = st, g()
+			st = sep and seps + #sep
+			return s:sub(segs, (seps or 0) - 1)
+		end
 	end
-	return function() if st then return getter(st, g()) end end
+	return getter
 end
 
 local create_lines = function(text)

--- a/lcd.lua
+++ b/lcd.lua
@@ -87,7 +87,7 @@ local generate_line = function(s, ypos)
 	width = width - 1
 
 	local texture = ""
-	local xpos = math.floor((LCD_WIDTH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
+	local xpos = math.floor((LCD_WIDTH - 2 * LCD_PADDING - width) / 2)
 	for ii = 1, #parsed do
 		texture = texture..":"..xpos..","..ypos.."="..parsed[ii]..".png"
 		xpos = xpos + CHAR_WIDTH + 1

--- a/lcd.lua
+++ b/lcd.lua
@@ -30,6 +30,11 @@ local NUMBER_OF_LINES = 5
 local LINE_HEIGHT = 14
 local CHAR_WIDTH = 5
 
+
+assert(CHAR_WIDTH * LINE_LENGTH <= LCD_WIDTH - LCD_PADDING*2, "LCD: Lines set too long!")
+assert(LINE_HEIGHT * NUMBER_OF_LINES <= LCD_WIDTH - LCD_PADDING*2, "LCD: Too many lines!")
+
+
 local split = function(s, pat)
 	-- adapted from https://stackoverflow.com/a/1647577/4067384
 	-- simplified for our only usecase
@@ -139,7 +144,7 @@ local generate_line = function(s, ypos)
 			i = i + 1
 		end
 		if file ~= nil then
-			width = width + CHAR_WIDTH
+			width = width + CHAR_WIDTH + 1
 			table.insert(parsed, file)
 			chars = chars + 1
 		end
@@ -147,7 +152,7 @@ local generate_line = function(s, ypos)
 	width = width - 1
 
 	local texture = ""
-	local xpos = math.floor((LCD_WIDTH - 2 * LCD_PADDING - width) / 2)
+	local xpos = math.floor((LCD_WIDTH - width) / 2)
 	for ii = 1, #parsed do
 		texture = texture..":"..xpos..","..ypos.."="..parsed[ii]..".png"
 		xpos = xpos + CHAR_WIDTH + 1

--- a/lcd.lua
+++ b/lcd.lua
@@ -96,7 +96,7 @@ local create_lines = function(text)
 						line = line .. " "
 						remaining = remaining - 1
 					end
-					if remaining - string.len(word) < 0 then
+					if remaining < string.len(word) then
 						line = line .. string.sub(word, 1, math.min(remaining, string.len(word)))
 						word = string.sub(word, remaining+1, string.len(word))
 						if flush_line_and_check_for_return() then return tab end

--- a/lcd.lua
+++ b/lcd.lua
@@ -5,7 +5,6 @@
 -- load characters map
 local chars_file = io.open(minetest.get_modpath("digilines").."/characters", "r")
 local charmap = {}
-local max_chars = 12
 if not chars_file then
 	print("[digilines] E: LCD: character map file not found")
 else
@@ -31,8 +30,8 @@ local LINE_HEIGHT = 14
 local CHAR_WIDTH = 5
 
 
-assert(CHAR_WIDTH * LINE_LENGTH <= LCD_WIDTH - LCD_PADDING*2, "LCD: Lines set too long!")
-assert(LINE_HEIGHT * NUMBER_OF_LINES <= LCD_WIDTH - LCD_PADDING*2, "LCD: Too many lines!")
+assert((CHAR_WIDTH+1) * LINE_LENGTH <= LCD_WIDTH - LCD_PADDING*2, "LCD: Lines set too long!")
+assert((LINE_HEIGHT+1) * NUMBER_OF_LINES <= LCD_WIDTH - LCD_PADDING*2, "LCD: Too many lines!")
 
 
 local split = function(s, pat)
@@ -128,7 +127,7 @@ local generate_line = function(s, ypos)
 	local parsed = {}
 	local width = 0
 	local chars = 0
-	while chars < max_chars and i <= #s do
+	while chars < LINE_LENGTH and i <= #s do
 		local file = nil
 		if charmap[s:sub(i, i)] ~= nil then
 			file = charmap[s:sub(i, i)]
@@ -162,7 +161,7 @@ end
 
 local generate_texture = function(lines)
 	local texture = "[combine:"..LCD_WIDTH.."x"..LCD_WIDTH
-	local ypos = 16
+	local ypos = math.floor((LCD_WIDTH - LINE_HEIGHT*NUMBER_OF_LINES) / 2)
 	for i = 1, #lines do
 		texture = texture..generate_line(lines[i], ypos)
 		ypos = ypos + LINE_HEIGHT

--- a/lcd.lua
+++ b/lcd.lua
@@ -34,7 +34,7 @@ local create_lines = function(text)
 	local line = ""
 	local line_num = 1
 	local tab = {}
-	for word in string.gmatch(text, "%S+") do
+	for word in string.gmatch(text, "%S*") do
 		if string.len(line)+string.len(word) < LINE_LENGTH and word ~= "|" then
 			if line ~= "" then
 				line = line.." "..word
@@ -43,7 +43,9 @@ local create_lines = function(text)
 			end
 		else
 			table.insert(tab, line)
-			if word ~= "|" then
+			if word == " " then
+				-- don't at the space since we have a line break
+			elseif word ~= "|" then
 				line = word
 			else
 				line = ""

--- a/lcd.lua
+++ b/lcd.lua
@@ -35,7 +35,7 @@ local create_lines = function(text)
 	local line_num = 1
 	local tab = {}
 	for word in string.gmatch(text, "%S*") do
-		if string.len(line)+string.len(word) < LINE_LENGTH and word ~= "|" then
+		if (string.len(line) and string.len(line)+1) + string.len(word) <= LINE_LENGTH and word ~= "|" then
 			if line ~= "" then
 				line = line.." "..word
 			else

--- a/lcd.lua
+++ b/lcd.lua
@@ -98,7 +98,7 @@ local create_lines = function(text)
 					end
 					if remaining < string.len(word) then
 						line = line .. string.sub(word, 1, remaining)
-						word = string.sub(word, remaining+1, string.len(word))
+						word = string.sub(word, remaining+1)
 						if flush_line_and_check_for_return() then return tab end
 					else
 						-- used up the word

--- a/lcd.lua
+++ b/lcd.lua
@@ -73,6 +73,9 @@ local generate_line = function(s, ypos)
 			i = i + 2
 		else
 			print("[digilines] W: LCD: unknown symbol in '"..s.."' at "..i)
+			if charmap[" "] ~= nil then
+				file = charmap[" "]
+			end
 			i = i + 1
 		end
 		if file ~= nil then

--- a/lcd.lua
+++ b/lcd.lua
@@ -97,7 +97,7 @@ local create_lines = function(text)
 						remaining = remaining - 1
 					end
 					if remaining < string.len(word) then
-						line = line .. string.sub(word, 1, math.min(remaining, string.len(word)))
+						line = line .. string.sub(word, 1, remaining)
 						word = string.sub(word, remaining+1, string.len(word))
 						if flush_line_and_check_for_return() then return tab end
 					else

--- a/lcd.lua
+++ b/lcd.lua
@@ -21,7 +21,7 @@ else
 end
 
 -- CONSTANTS
-local LCD_WITH = 100
+local LCD_WIDTH = 100
 local LCD_PADDING = 8
 
 local LINE_LENGTH = 12
@@ -87,7 +87,7 @@ local generate_line = function(s, ypos)
 	width = width - 1
 
 	local texture = ""
-	local xpos = math.floor((LCD_WITH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
+	local xpos = math.floor((LCD_WIDTH - 2 * LCD_PADDING - width) / 2 + LCD_PADDING)
 	for ii = 1, #parsed do
 		texture = texture..":"..xpos..","..ypos.."="..parsed[ii]..".png"
 		xpos = xpos + CHAR_WIDTH + 1
@@ -96,7 +96,7 @@ local generate_line = function(s, ypos)
 end
 
 local generate_texture = function(lines)
-	local texture = "[combine:"..LCD_WITH.."x"..LCD_WITH
+	local texture = "[combine:"..LCD_WIDTH.."x"..LCD_WIDTH
 	local ypos = 16
 	for i = 1, #lines do
 		texture = texture..generate_line(lines[i], ypos)


### PR DESCRIPTION
This PR succeeds and replaces #62.

Typeset the lines according to these rules (in order of subjective significance):
- words that fit on the screen but would let the current line overflow are placed on a new line instead
- " | " always forces a linebreak
- spaces are included, except when there is a linebreak anyway
- words with more characters than fit on screen are just chopped up, filling the lines as full as possible
- don't bother typesetting more lines than fit on screen
- if we are on the last line that will fit on screen