### PR TITLE
Fix wires not connecting to nodes using the `digilines` definition 

### DIFF
--- a/inventory.lua
+++ b/inventory.lua
@@ -97,7 +97,7 @@ minetest.register_node("digilines:chest", {
 			minetest.get_meta(pos):set_string("channel",fields.channel)
 		end
 	end,
-	digiline = {
+	digilines = {
 		receptor = {},
 		effector = {
 			action = function() end

--- a/lcd.lua
+++ b/lcd.lua
@@ -313,7 +313,7 @@ minetest.register_node("digilines:lcd", {
 			minetest.get_meta(pos):set_string("channel", fields.channel)
 		end
 	end,
-	digiline = {
+	digilines = {
 		receptor = {},
 		effector = {
 			action = on_digiline_receive

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -39,7 +39,7 @@ minetest.register_node("digilines:lightsensor", {
 	groups = {dig_immediate=2},
 	selection_box = lsensor_selbox,
 	node_box = lsensor_nodebox,
-	digiline =
+	digilines =
 	{
 		receptor = {},
 		effector = {

--- a/rtc.lua
+++ b/rtc.lua
@@ -35,7 +35,7 @@ minetest.register_node("digilines:rtc", {
 	groups = {dig_immediate=2},
 	selection_box = rtc_selbox,
 	node_box = rtc_nodebox,
-	digiline =
+	digilines =
 	{
 		receptor = {},
 		effector = {

--- a/wire_std.lua
+++ b/wire_std.lua
@@ -90,7 +90,7 @@ for zmy=0, 1 do
 		paramtype = "light",
 		paramtype2 = "facedir",
 		sunlight_propagates = true,
-		digiline =
+		digilines =
 		{
 			wire =
 			{

--- a/wires_common.lua
+++ b/wires_common.lua
@@ -1,15 +1,12 @@
-minetest.register_on_placenode(function(pos, node)
-	if minetest.registered_nodes[node.name].digiline then
-		digilines.update_autoconnect(pos)
-	end
-end)
 
-minetest.register_on_dignode(function(pos, node)
-	if minetest.registered_nodes[node.name] and minetest.registered_nodes[node.name].digiline then
--- need to make sure that node exists (unknown nodes!)
+local function check_and_update(pos, node)
+	if digilines.getspec(node) then
 		digilines.update_autoconnect(pos)
 	end
-end)
+end
+
+minetest.register_on_placenode(check_and_update)
+minetest.register_on_dignode(check_and_update)
 
 function digilines.update_autoconnect(pos, secondcall)
 	local xppos = {x=pos.x+1, y=pos.y, z=pos.z}
@@ -42,8 +39,7 @@ function digilines.update_autoconnect(pos, secondcall)
 		digilines.update_autoconnect(zmympos, true)
 	end
 
-	local def = minetest.registered_nodes[minetest.get_node(pos).name]
-	local digilinespec = def and def.digiline
+	local digilinespec = digilines.getspec(minetest.get_node(pos))
 	if not (digilinespec and digilinespec.wire and
 			digilinespec.wire.use_autoconnect) then
 		return nil


### PR DESCRIPTION
Currently wires only connect to nodes using the deprecated `digiline` definition, this fixes that by also checking for the `digilines` definition.

Also updates all the nodes to use the correct definition.

Related: #44 #47