### PR TITLE
Add craft recipes for RTC and Lightsensor

### DIFF
--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -61,3 +61,11 @@ minetest.register_node("digilines:lightsensor", {
 		end
 	end,
 })
+
+minetest.register_craft({
+	output = "digilines:lightsensor",
+	recipe = {
+		{"default:glass","default:glass","default:glass"},
+		{"default:steel_ingot", "digilines:wire_std_00000000", "default:steel_ingot"},
+	}
+})

--- a/rtc.lua
+++ b/rtc.lua
@@ -57,3 +57,12 @@ minetest.register_node("digilines:rtc", {
 		end
 	end,
 })
+
+minetest.register_craft({
+	output = "digilines:rtc",
+	recipe = {
+		{"", "dye:black", ""},
+		{"default:steel_ingot", "default:mese_crystal_fragment", "default:steel_ingot"},
+		{"", "digilines:wire_std_00000000", ""}
+	}
+})


### PR DESCRIPTION
Adds craft recipes for `digilines:rtc` and `digilines:lightsensor`, both of which have never had recipes.