### PR TITLE
don't record a protection violation when players aren't allowed to modify a node

### DIFF
--- a/inventory.lua
+++ b/inventory.lua
@@ -185,7 +185,6 @@ minetest.register_node("digilines:chest", {
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
-			minetest.record_protection_violation(pos, name)
 			return
 		end
 		if fields.channel ~= nil then

--- a/lcd.lua
+++ b/lcd.lua
@@ -310,7 +310,6 @@ minetest.register_node("digilines:lcd", {
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
-			minetest.record_protection_violation(pos, name)
 			return
 		end
 		if (fields.channel) then

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -55,7 +55,6 @@ minetest.register_node("digilines:lightsensor", {
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
-			minetest.record_protection_violation(pos, name)
 			return
 		end
 		if (fields.channel) then

--- a/rtc.lua
+++ b/rtc.lua
@@ -51,7 +51,6 @@ minetest.register_node("digilines:rtc", {
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
 		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
-			minetest.record_protection_violation(pos, name)
 			return
 		end
 		if (fields.channel) then


### PR DESCRIPTION
protection violations are used to punish players who are making use of game mechanics to exploit protection, e.g. trying to dig through a protected area or climb up the side of a building by placing nodes, and relying on client-side predictions. punishing players for poking at a protected node's formspec, or even just *closing* it, is not only pointless, but counter-productive. 