### PR TITLE
Add `initial_properties` for text entity

### DIFF
--- a/lcd.lua
+++ b/lcd.lua
@@ -336,9 +336,11 @@ minetest.register_lbm({
 })
 
 minetest.register_entity(":digilines_lcd:text", {
-	collisionbox = { 0, 0, 0, 0, 0, 0 },
-	visual = "upright_sprite",
-	textures = {},
+	initial_properties = {
+		collisionbox = { 0, 0, 0, 0, 0, 0 },
+		visual = "upright_sprite",
+		textures = {},
+	},
 	on_activate = set_texture,
 })
 


### PR DESCRIPTION
Seems to work fine ingame + no warning in the log.