### PR TITLE
Disallow LCD messages that aren't strings or numbers

### DIFF
--- a/lcd.lua
+++ b/lcd.lua
@@ -259,6 +259,8 @@ local on_digiline_receive = function(pos, _, channel, msg)
 	local setchan = meta:get_string("channel")
 	if setchan ~= channel then return end
 
+	if type(msg) ~= "string" and type(msg) ~= "number" then return end
+
 	meta:set_string("text", msg)
 	meta:set_string("infotext", msg)
 


### PR DESCRIPTION
This fixes a crash (that seems to only happen in 5.9?) that occurs if a table is sent to an LCD.