### PR TITLE
Added screen mode LCD

### DIFF
--- a/lcd.lua
+++ b/lcd.lua
@@ -188,18 +188,22 @@ local generate_raster_texture = function(colors)
 	local width = total_width - w_padding * 2
 	local height = total_width - h_padding * 2
 
-	local texture = "lcd_anyside.png^[resize:"..total_width.."x"..total_width
+	-- using escapes for the combine at the end
+	local texture = "lcd_anyside.png\\^[resize\\:"..total_width.."x"..total_width
 
 	if type(colors) == "table" then
 		local pixels = {}
-		for i, num in ipairs(colors) do
-			if i > width * height then break end
-			local color = number_to_color(num)
-			local x = (i - 1) % width
-			local y = math.floor((i - 1) / width)
-			pixels[i] = "^[fill:1x1:"..x + w_padding ..","..y + h_padding..":"..color
+		for i = 1, width * height do
+			local color = "#0000"
+			if (i <= #colors) then
+				color = number_to_color(colors[i])
+			end
+			pixels[i] = color
 		end
-		texture = texture .. table.concat(pixels)
+		local png = minetest.encode_base64(minetest.encode_png(width, height, pixels))
+		texture = "[combine:"..total_width.."x"..total_width
+			..":0,0="..texture
+			..":"..w_padding..","..h_padding.."=[png\\:"..png
 	end
 
 	return texture

--- a/lcd.lua
+++ b/lcd.lua
@@ -188,25 +188,7 @@ local generate_raster_texture = function(colors)
 	local width = total_width - w_padding * 2
 	local height = total_width - h_padding * 2
 
-	local texture = "[fill:"..total_width.."x"..total_width..":#0000"
-
-	-- the LCD's frame
-	-- top
-	texture = texture
-		.."^[fill:"..total_width.."x"..h_padding
-		..":0,0:#000"
-	-- bottom
-	texture = texture
-		.."^[fill:"..total_width.."x"..h_padding
-		..":0,"..total_width - h_padding..":#000"
-	-- left
-	texture = texture
-		.."^[fill:"..w_padding.."x"..total_width - h_padding
-		..":0,"..h_padding..":#000"
-	-- right
-	texture = texture
-		.."^[fill:"..w_padding.."x"..total_width - h_padding
-		..":".. total_width - w_padding ..","..h_padding..":#000"
+	local texture = "lcd_anyside.png^[resize:"..total_width.."x"..total_width
 
 	if type(colors) == "table" then
 		for i, num in ipairs(colors) do

--- a/lcd.lua
+++ b/lcd.lua
@@ -182,20 +182,31 @@ end
 local generate_raster_texture = function(colors)
 	-- the LCD texture is 16x16, will upscale the resolution by 4
 	local total_width = 16 * 4
-	local h_padding = 1 * 4
-	local v_padding = 2 * 4
+	local w_padding = 1 * 4
+	local h_padding = 2 * 4
 
-	local width = total_width - h_padding * 2
-	local height = total_width - v_padding * 2
+	local width = total_width - w_padding * 2
+	local height = total_width - h_padding * 2
 
 	local texture = "[fill:"..total_width.."x"..total_width..":#0000"
+
+	-- the LCD's frame
+	-- top
+	texture = texture .. "^[fill:"..total_width.."x"..h_padding..":0,0:#000"
+	-- bottom
+	texture = texture .. "^[fill:"..total_width.."x"..h_padding..":0,"..total_width - h_padding..":#000"
+	-- left
+	texture = texture .. "^[fill:"..w_padding.."x"..total_width - h_padding..":0,"..h_padding..":#000"
+	-- right
+	texture = texture .. "^[fill:"..w_padding.."x"..total_width - h_padding..":".. total_width - w_padding ..","..h_padding..":#000"
+
 	if type(colors) == "table" then
 		for i, num in ipairs(colors) do
 			if i > width * height then break end
 			local color = number_to_color(num)
 			local x = (i - 1) % width
 			local y = math.floor((i - 1) / width)
-			texture = texture .. "^[fill:1x1:"..x + h_padding ..","..y + v_padding..":"..color
+			texture = texture .. "^[fill:1x1:"..x + w_padding ..","..y + h_padding..":"..color
 		end
 	end
 

--- a/lcd.lua
+++ b/lcd.lua
@@ -161,13 +161,44 @@ local generate_line = function(s, ypos)
 	return texture
 end
 
-local generate_texture = function(lines)
+local generate_text_texture = function(lines)
 	local texture = "[combine:"..LCD_WIDTH.."x"..LCD_WIDTH
 	local ypos = math.floor((LCD_WIDTH - LINE_HEIGHT*NUMBER_OF_LINES) / 2)
 	for i = 1, #lines do
 		texture = texture..generate_line(lines[i], ypos)
 		ypos = ypos + LINE_HEIGHT
 	end
+	return texture
+end
+
+local number_to_color = function(num)
+	if type(num) ~= "number" or num >= 4096 or num < 0 then
+		return "#0000"
+	end
+
+	return string.format("#%X%X%X", num / 16^2, num / 16 % 16, num % 16 )
+end
+
+local generate_raster_texture = function(colors)
+	-- the LCD texture is 16x16, will upscale the resolution by 4
+	local total_width = 16 * 4
+	local h_padding = 1 * 4
+	local v_padding = 2 * 4
+
+	local width = total_width - h_padding * 2
+	local height = total_width - v_padding * 2
+
+	local texture = "[fill:"..total_width.."x"..total_width..":#0000"
+	if type(colors) == "table" then
+		for i, num in ipairs(colors) do
+			if i > width * height then break end
+			local color = number_to_color(num)
+			local x = (i - 1) % width
+			local y = math.floor((i - 1) / width)
+			texture = texture .. "^[fill:1x1:"..x + h_padding ..","..y + v_padding..":"..color
+		end
+	end
+
 	return texture
 end
 
@@ -202,10 +233,18 @@ end
 
 local set_texture = function(ent)
 	local meta = minetest.get_meta(ent.object:get_pos())
-	local text = meta:get_string("text")
+	local message = meta:get_string("message")
+	local message_type = meta:get_string("message_type")
+	
+	local texture
+	if message_type == "string" then
+		texture = generate_text_texture(create_lines(message))
+	else
+		texture = generate_raster_texture(minetest.deserialize(message))
+	end
 	ent.object:set_properties({
 		textures = {
-			generate_texture(create_lines(text))
+			texture
 		}
 	})
 end
@@ -260,12 +299,19 @@ local on_digiline_receive = function(pos, _, channel, msg)
 	local setchan = meta:get_string("channel")
 	if setchan ~= channel then return end
 
-	if type(msg) ~= "string" and type(msg) ~= "number" then return end
+	if type(msg) == "string" or type(msg) == "number" then
+		meta:set_string("message", msg)
+		meta:set_string("infotext", msg)
+	elseif type(msg) == "table" then
+		meta:set_string("message", minetest.serialize(msg))
+		meta:set_string("infotext", "")
+	else
+		return
+	end
 
-	meta:set_string("text", msg)
-	meta:set_string("infotext", msg)
+	meta:set_string("message_type", type(msg))
 
-	if msg ~= "" then
+	if type(msg) ~= string or msg ~= "" then
 		prepare_writing(pos)
 	end
 end

--- a/lcd.lua
+++ b/lcd.lua
@@ -191,13 +191,15 @@ local generate_raster_texture = function(colors)
 	local texture = "lcd_anyside.png^[resize:"..total_width.."x"..total_width
 
 	if type(colors) == "table" then
+		local pixels = {}
 		for i, num in ipairs(colors) do
 			if i > width * height then break end
 			local color = number_to_color(num)
 			local x = (i - 1) % width
 			local y = math.floor((i - 1) / width)
-			texture = texture .. "^[fill:1x1:"..x + w_padding ..","..y + h_padding..":"..color
+			pixels[i] = "^[fill:1x1:"..x + w_padding ..","..y + h_padding..":"..color
 		end
+		texture = texture .. table.concat(pixels)
 	end
 
 	return texture

--- a/lcd.lua
+++ b/lcd.lua
@@ -192,13 +192,21 @@ local generate_raster_texture = function(colors)
 
 	-- the LCD's frame
 	-- top
-	texture = texture .. "^[fill:"..total_width.."x"..h_padding..":0,0:#000"
+	texture = texture
+		.."^[fill:"..total_width.."x"..h_padding
+		..":0,0:#000"
 	-- bottom
-	texture = texture .. "^[fill:"..total_width.."x"..h_padding..":0,"..total_width - h_padding..":#000"
+	texture = texture
+		.."^[fill:"..total_width.."x"..h_padding
+		..":0,"..total_width - h_padding..":#000"
 	-- left
-	texture = texture .. "^[fill:"..w_padding.."x"..total_width - h_padding..":0,"..h_padding..":#000"
+	texture = texture
+		.."^[fill:"..w_padding.."x"..total_width - h_padding
+		..":0,"..h_padding..":#000"
 	-- right
-	texture = texture .. "^[fill:"..w_padding.."x"..total_width - h_padding..":".. total_width - w_padding ..","..h_padding..":#000"
+	texture = texture
+		.."^[fill:"..w_padding.."x"..total_width - h_padding
+		..":".. total_width - w_padding ..","..h_padding..":#000"
 
 	if type(colors) == "table" then
 		for i, num in ipairs(colors) do
@@ -246,7 +254,7 @@ local set_texture = function(ent)
 	local meta = minetest.get_meta(ent.object:get_pos())
 	local message = meta:get_string("message")
 	local message_type = meta:get_string("message_type")
-	
+
 	local texture
 	if message_type == "string" then
 		texture = generate_text_texture(create_lines(message))


### PR DESCRIPTION
I thought it would be interesting having the capability to display individual pixels on the LCD screen, so I made this feature.

It doesn't change the behavior when the LCD receives a string, but when it receives a table it will draw each individual pixel with 4096 possible colors (4 bits per channel).
