### PR TITLE
[NO SQUASH] Add (x=0,y=-1,z=0) rule to light sensor

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,7 +5,6 @@ read_globals = {
 	"dump",
 
 	"core",
-	"core",
 	"vector",
 	"ItemStack",
 	"VoxelArea",
@@ -14,6 +13,7 @@ read_globals = {
 	"pipeworks",
 	"screwdriver",
 
+	table = { fields = { "copy" } },
 }
 
 globals = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,7 +5,7 @@ read_globals = {
 	"dump",
 
 	"core",
-	"minetest",
+	"core",
 	"vector",
 	"ItemStack",
 	"VoxelArea",

--- a/init.lua
+++ b/init.lua
@@ -1,15 +1,15 @@
 digilines = {}
-digilines.S = minetest.get_translator("digilines")
+digilines.S = core.get_translator("digilines")
 
 -- formspec escape translation
 digilines.FS = function (...)
-	return minetest.formspec_escape(digilines.S(...))
+	return core.formspec_escape(digilines.S(...))
 end
 
-digilines.mcl = minetest.get_modpath("mcl_core")
+digilines.mcl = core.get_modpath("mcl_core")
 
 -- sounds check
-if minetest.get_modpath("default") then digilines.sounds = default end
+if core.get_modpath("default") then digilines.sounds = default end
 if digilines.mcl then digilines.sounds = mcl_sounds end
 
 -- Show a more helpful error message to the player
@@ -53,7 +53,7 @@ assert(digilines._testproxy("foobar") == "foobar")
 -- Test calling incorrect form raises an error.
 assert(not pcall(function() digiline._testproxy("foobar") end))
 
-local modpath = minetest.get_modpath("digilines")
+local modpath = core.get_modpath("digilines")
 dofile(modpath .. "/presetrules.lua")
 dofile(modpath .. "/util.lua")
 dofile(modpath .. "/internal.lua")
@@ -62,7 +62,7 @@ dofile(modpath .. "/wire_std.lua")
 
 function digilines.receptor_send(pos, rules, channel, msg)
 	local checked = {}
-	checked[minetest.hash_node_position(pos)] = true -- exclude itself
+	checked[core.hash_node_position(pos)] = true -- exclude itself
 	for _,rule in ipairs(rules) do
 		if digilines.rules_link(pos, digilines.addPosRule(pos, rule)) then
 			digilines.transmit(digilines.addPosRule(pos, rule), channel, msg, checked)
@@ -77,12 +77,12 @@ local gold_ingot = "default:gold_ingot"
 if digilines.mcl then
 	gold_ingot = "mcl_core:gold_ingot"
 	-- MCL dont support mesecons insulated
-	if not minetest.get_modpath("mesecons_insulated") then
+	if not core.get_modpath("mesecons_insulated") then
 		insulated = "mesecons:redstone"
 	end
 end
 
-minetest.register_craft({
+core.register_craft({
 	output = 'digilines:wire_std_00000000 2',
 	recipe = {
 		{fiber, fiber, fiber},
@@ -92,18 +92,18 @@ minetest.register_craft({
 })
 
 -- For minetest 0.4 support returned nil are also tested:  ~= false
-if minetest.settings:get_bool("digilines_enable_inventory", true) ~= false then
+if core.settings:get_bool("digilines_enable_inventory", true) ~= false then
 	dofile(modpath .. "/inventory.lua")
 end
 
-if minetest.settings:get_bool("digilines_enable_lcd", true) ~= false then
+if core.settings:get_bool("digilines_enable_lcd", true) ~= false then
 	dofile(modpath .. "/lcd.lua")
 end
 
-if minetest.settings:get_bool("digilines_enable_lightsensor", true) ~= false then
+if core.settings:get_bool("digilines_enable_lightsensor", true) ~= false then
 	dofile(modpath .. "/lightsensor.lua")
 end
 
-if minetest.settings:get_bool("digilines_enable_rtc", true) ~= false then
+if core.settings:get_bool("digilines_enable_rtc", true) ~= false then
 	dofile(modpath .. "/rtc.lua")
 end

--- a/internal.lua
+++ b/internal.lua
@@ -1,5 +1,5 @@
 function digilines.getspec(node)
-	local def = minetest.registered_nodes[node.name]
+	local def = core.registered_nodes[node.name]
 	if not def then return false end
 	return def.digilines or def.digiline
 end
@@ -87,7 +87,7 @@ local function queue_dequeue(queue)
 end
 
 function digilines.transmit(pos, channel, msg, checked)
-	local checkedID = minetest.hash_node_position(pos)
+	local checkedID = core.hash_node_position(pos)
 	if checked[checkedID] then
 		return
 	end
@@ -112,7 +112,7 @@ function digilines.transmit(pos, channel, msg, checked)
 				for _, rule in ipairs(rules) do
 					local nextPos = digilines.addPosRule(curPos, rule)
 					if digilines.rules_link(curPos, nextPos) then
-						local checkedID2 = minetest.hash_node_position(nextPos)
+						local checkedID2 = core.hash_node_position(nextPos)
 						if not checked[checkedID2] then
 							checked[checkedID2] = true
 							queue_enqueue(queue, nextPos)

--- a/inventory.lua
+++ b/inventory.lua
@@ -3,7 +3,7 @@ assert(core.features.dynamic_add_media_table,
 
 local S = digilines.S
 
-local pipeworks_enabled = minetest.get_modpath("pipeworks") ~= nil
+local pipeworks_enabled = core.get_modpath("pipeworks") ~= nil
 
 -- Sends a message onto the Digilines network.
 -- pos: the position of the Digilines chest node.
@@ -13,7 +13,7 @@ local pipeworks_enabled = minetest.get_modpath("pipeworks") ~= nil
 -- to_slot: the slot number that is put into (optional).
 -- side: which side of the chest the action occurred (optional).
 local function send_message(pos, action, stack, from_slot, to_slot, side)
-	local channel = minetest.get_meta(pos):get_string("channel")
+	local channel = core.get_meta(pos):get_string("channel")
 	local msg = {
 		action = action,
 		stack = stack and stack:to_table(),
@@ -27,7 +27,7 @@ end
 
 -- Checks if the inventory has become empty and, if so, sends an empty message.
 local function send_empty_if_empty(pos)
-	if minetest.get_meta(pos):get_inventory():is_empty("main") then
+	if core.get_meta(pos):get_inventory():is_empty("main") then
 		send_message(pos, "empty")
 	end
 end
@@ -37,7 +37,7 @@ end
 local function send_full_if_full(pos, stack)
 	local one_item_stack = ItemStack(stack)
 	one_item_stack:set_count(1)
-	if not minetest.get_meta(pos):get_inventory():room_for_item("main", one_item_stack) then
+	if not core.get_meta(pos):get_inventory():room_for_item("main", one_item_stack) then
 		send_message(pos, "full", one_item_stack)
 	end
 end
@@ -46,7 +46,7 @@ local tubeconn = pipeworks_enabled and "^pipeworks_tube_connection_wooden.png" o
 local tubescan = pipeworks_enabled and function(pos) pipeworks.scan_for_tube_objects(pos) end or nil
 
 local tube_can_insert = function(pos, _, stack, direction)
-	local ret = minetest.get_meta(pos):get_inventory():room_for_item("main", stack)
+	local ret = core.get_meta(pos):get_inventory():room_for_item("main", stack)
 	if not ret then
 		-- The stack cannot be accepted. It will never be passed to
 		-- insert_object, but it should be reported as a toverflow.
@@ -61,7 +61,7 @@ end
 local tube_insert_object = function(pos, _, original_stack, direction)
 	-- Here, direction = direction item is moving, which is into side.
 	local side = vector.multiply(direction, -1)
-	local inv = minetest.get_meta(pos):get_inventory()
+	local inv = core.get_meta(pos):get_inventory()
 	local inv_contents = inv:get_list("main")
 	local any_put = false
 	local stack = original_stack
@@ -140,14 +140,14 @@ end
 
 local formspec_header = ""
 
-if minetest.get_modpath("mcl_formspec") then
+if core.get_modpath("mcl_formspec") then
 	formspec_header = mcl_formspec.get_itemslot_bg(0,1,8,4)..
 		mcl_formspec.get_itemslot_bg(0,6,8,4)
 end
 
-minetest.register_alias("digilines_inventory:chest", "digilines:chest")
+core.register_alias("digilines_inventory:chest", "digilines:chest")
 
-minetest.register_node("digilines:chest", {
+core.register_node("digilines:chest", {
 	description = S("Digiline Chest"),
 	tiles = {
 		"default_chest_top.png"..tubeconn,
@@ -165,7 +165,7 @@ minetest.register_node("digilines:chest", {
 	_mcl_blast_resistance = 1,
 	_mcl_hardness = 0.8,
 	on_construct = function(pos)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		meta:set_string("infotext", S("Digiline Chest"))
 		meta:set_string("formspec", "size[8,10]"..
 			formspec_header..
@@ -181,15 +181,15 @@ minetest.register_node("digilines:chest", {
 	after_place_node = tubescan,
 	after_dig_node = tubescan,
 	can_dig = function(pos)
-		return minetest.get_meta(pos):get_inventory():is_empty("main")
+		return core.get_meta(pos):get_inventory():is_empty("main")
 	end,
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
-		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+		if core.is_protected(pos, name) and not core.check_player_privs(name, {protection_bypass=true}) then
 			return
 		end
 		if fields.channel ~= nil then
-			minetest.get_meta(pos):set_string("channel",fields.channel)
+			core.get_meta(pos):set_string("channel",fields.channel)
 		end
 	end,
 	digilines = {
@@ -221,14 +221,14 @@ minetest.register_node("digilines:chest", {
 	},
 	on_metadata_inventory_move = function(pos, _, from_index, _, to_index, count, player)
 		-- Detect stack swaps (in the same inventory) by trying to add them together.
-		local inv = minetest.get_meta(pos):get_inventory()
+		local inv = core.get_meta(pos):get_inventory()
 		local from_stack = inv:get_stack("main", from_index)
 		local to_stack = inv:get_stack("main", to_index)
 		local reverse_move_stack = ItemStack(to_stack)
 		reverse_move_stack:set_count(count)
 		local swapped = from_stack:add_item(reverse_move_stack):get_count() == count
 		if swapped then
-			local channel = minetest.get_meta(pos):get_string("channel")
+			local channel = core.get_meta(pos):get_string("channel")
 			to_stack:set_count(count)
 			local msg = {
 				action = "uswap",
@@ -246,21 +246,21 @@ minetest.register_node("digilines:chest", {
 			to_stack:set_count(count)
 			send_message(pos, "umove", to_stack, from_index, to_index)
 		end
-		minetest.log("action", player:get_player_name().." moves stuff in chest at "..minetest.pos_to_string(pos))
+		core.log("action", player:get_player_name().." moves stuff in chest at "..core.pos_to_string(pos))
 	end,
 	on_metadata_inventory_put = function(pos, _, index, stack, player)
 		send_message(pos, "uput", stack, nil, index)
 		send_full_if_full(pos, stack)
-		minetest.log("action", player:get_player_name().." puts stuff into chest at "..minetest.pos_to_string(pos))
+		core.log("action", player:get_player_name().." puts stuff into chest at "..core.pos_to_string(pos))
 	end,
 	on_metadata_inventory_take = function(pos, _, index, stack, player)
 		send_message(pos, "utake", stack, index)
 		send_empty_if_empty(pos)
-		minetest.log("action", player:get_player_name().." takes stuff from chest at "..minetest.pos_to_string(pos))
+		core.log("action", player:get_player_name().." takes stuff from chest at "..core.pos_to_string(pos))
 	end
 })
 
-if minetest.global_exists("tubelib") then
+if core.global_exists("tubelib") then
 	local speculative_pull = nil
 	local pull_succeeded = function(passed_speculative_pull)
 		if passed_speculative_pull.canceled then return end
@@ -273,15 +273,15 @@ if minetest.global_exists("tubelib") then
 		if side == "U" then return {x=0,y=-1,z=0}
 		elseif side == "D" then return {x=0,y=1,z=0}
 		end
-		local param2 = minetest.get_node(pos).param2
+		local param2 = core.get_node(pos).param2
 		return vector.multiply(
-			minetest.facedir_to_dir(
+			core.facedir_to_dir(
 				tubelib2.side_to_dir(side, param2) - 1),
 			-1)
 	end
 	tubelib.register_node("digilines:chest", {}, {
 		on_pull_stack = function(pos, side, _)
-			local inv = minetest.get_meta(pos):get_inventory()
+			local inv = core.get_meta(pos):get_inventory()
 			for i, stack in pairs(inv:get_list("main")) do
 				if not stack:is_empty() then
 					speculative_pull = {
@@ -291,7 +291,7 @@ if minetest.global_exists("tubelib") then
 						index = i,
 						dir = tube_side(pos, side)
 					}
-					minetest.after(0, pull_succeeded, speculative_pull)
+					core.after(0, pull_succeeded, speculative_pull)
 					inv:set_stack("main", i, nil)
 					return stack
 				end
@@ -299,7 +299,7 @@ if minetest.global_exists("tubelib") then
 			return nil
 		end,
 		on_pull_item = function(pos, side, _)
-			local inv = minetest.get_meta(pos):get_inventory()
+			local inv = core.get_meta(pos):get_inventory()
 			for i, stack in pairs(inv:get_list("main")) do
 				if not stack:is_empty() then
 					local taken = stack:take_item(1)
@@ -310,7 +310,7 @@ if minetest.global_exists("tubelib") then
 						index = i,
 						dir = tube_side(pos, side)
 					}
-					minetest.after(0, pull_succeeded, speculative_pull)
+					core.after(0, pull_succeeded, speculative_pull)
 					inv:set_stack("main", i, stack)
 					return taken
 				end
@@ -326,7 +326,7 @@ if minetest.global_exists("tubelib") then
 			return true
 		end,
 		on_unpull_item = function(pos, _, item, _)
-			local inv = minetest.get_meta(pos):get_inventory()
+			local inv = core.get_meta(pos):get_inventory()
 			if not inv:room_for_item("main", item) then
 				return false
 			end
@@ -352,11 +352,11 @@ end
 
 local chest = "default:chest"
 
-if minetest.get_modpath("mcl_chests") then
+if core.get_modpath("mcl_chests") then
 	chest = "mcl_chests:chest"
 end
 
-minetest.register_craft({
+core.register_craft({
 	type = "shapeless",
 	output = "digilines:chest",
 	recipe = {chest, "digilines:wire_std_00000000"}

--- a/lcd.lua
+++ b/lcd.lua
@@ -6,7 +6,7 @@ local FS = digilines.FS
 -- Font: 04.jp.org
 
 -- load characters map
-local chars_file = io.open(minetest.get_modpath("digilines").."/characters", "r")
+local chars_file = io.open(core.get_modpath("digilines").."/characters", "r")
 local charmap = {}
 if not chars_file then
 	print("[digilines] E: LCD: character map file not found")
@@ -191,11 +191,11 @@ local lcds = {
 }
 
 local reset_meta = function(pos)
-	minetest.get_meta(pos):set_string("formspec", "field[channel;"..FS("Channel")..";${channel}]")
+	core.get_meta(pos):set_string("formspec", "field[channel;"..FS("Channel")..";${channel}]")
 end
 
 local clearscreen = function(pos)
-	local objects = minetest.get_objects_inside_radius(pos, 0.5)
+	local objects = core.get_objects_inside_radius(pos, 0.5)
 	for _, o in ipairs(objects) do
 		local o_entity = o:get_luaentity()
 		if o_entity and o_entity.name == "digilines_lcd:text" then
@@ -205,7 +205,7 @@ local clearscreen = function(pos)
 end
 
 local set_texture = function(ent)
-	local meta = minetest.get_meta(ent.object:get_pos())
+	local meta = core.get_meta(ent.object:get_pos())
 	local text = meta:get_string("text")
 	ent.object:set_properties({
 		textures = {
@@ -216,7 +216,7 @@ end
 
 local get_entity = function(pos)
 	local lcd_entity
-	local objects = minetest.get_objects_inside_radius(pos, 0.5)
+	local objects = core.get_objects_inside_radius(pos, 0.5)
 	for _, o in ipairs(objects) do
 		local o_entity = o:get_luaentity()
 		if o_entity and o_entity.name == "digilines_lcd:text" then
@@ -236,7 +236,7 @@ local rotate_text = function(pos, param)
 	if not entity then
 		return
 	end
-	local lcd_info = lcds[param or minetest.get_node(pos).param2]
+	local lcd_info = lcds[param or core.get_node(pos).param2]
 	if not lcd_info then
 		return
 	end
@@ -254,13 +254,13 @@ end
 
 local spawn_entity = function(pos)
 	if not get_entity(pos) then
-		minetest.add_entity(pos, "digilines_lcd:text")
+		core.add_entity(pos, "digilines_lcd:text")
 		rotate_text(pos)
 	end
 end
 
 local on_digiline_receive = function(pos, _, channel, msg)
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 	local setchan = meta:get_string("channel")
 	if setchan ~= channel then return end
 
@@ -279,8 +279,8 @@ local lcd_box = {
 	wall_top = {-8/16, 7/16, -8/16, 8/16, 8/16, 8/16}
 }
 
-minetest.register_alias("digilines_lcd:lcd", "digilines:lcd")
-minetest.register_node("digilines:lcd", {
+core.register_alias("digilines_lcd:lcd", "digilines:lcd")
+core.register_node("digilines:lcd", {
 	drawtype = "nodebox",
 	description = S("Digiline LCD"),
 	inventory_image = "lcd_lcd.png",
@@ -297,9 +297,9 @@ minetest.register_node("digilines:lcd", {
 	_mcl_blast_resistance = 1,
 	_mcl_hardness = 0.8,
 	after_place_node = function(pos)
-		local param2 = minetest.get_node(pos).param2
+		local param2 = core.get_node(pos).param2
 		if param2 == 0 or param2 == 1 then
-			minetest.add_node(pos, {name = "digilines:lcd", param2 = 3})
+			core.add_node(pos, {name = "digilines:lcd", param2 = 3})
 		end
 		spawn_entity(pos)
 		prepare_writing(pos)
@@ -307,7 +307,7 @@ minetest.register_node("digilines:lcd", {
 	on_construct = reset_meta,
 	on_destruct = clearscreen,
 	on_punch = function(pos, _, puncher, _)
-		if minetest.is_player(puncher) then
+		if core.is_player(puncher) then
 			spawn_entity(pos)
 		end
 	end,
@@ -319,11 +319,11 @@ minetest.register_node("digilines:lcd", {
 	end,
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
-		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+		if core.is_protected(pos, name) and not core.check_player_privs(name, {protection_bypass=true}) then
 			return
 		end
 		if (fields.channel) then
-			minetest.get_meta(pos):set_string("channel", fields.channel)
+			core.get_meta(pos):set_string("channel", fields.channel)
 		end
 	end,
 	digilines = {
@@ -334,7 +334,7 @@ minetest.register_node("digilines:lcd", {
 	},
 })
 
-minetest.register_lbm({
+core.register_lbm({
 	label = "Replace Missing Text Entities",
 	name = "digilines:replace_text",
 	nodenames = {"digilines:lcd"},
@@ -342,7 +342,7 @@ minetest.register_lbm({
 	action = spawn_entity,
 })
 
-minetest.register_entity(":digilines_lcd:text", {
+core.register_entity(":digilines_lcd:text", {
 	initial_properties = {
 		collisionbox = { 0, 0, 0, 0, 0, 0 },
 		visual = "upright_sprite",
@@ -361,7 +361,7 @@ if digilines.mcl then
 	lightstone = "mesecons_lightstone:lightstone_off"
 end
 
-minetest.register_craft({
+core.register_craft({
 	output = "digilines:lcd 2",
 	recipe = {
 		{steel_ingot, "digilines:wire_std_00000000", steel_ingot},

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -25,15 +25,15 @@ local lsensor_selbox =
 }
 
 local on_digiline_receive = function (pos, _, channel, msg)
-	local setchan = minetest.get_meta(pos):get_string("channel")
+	local setchan = core.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
-		local lightval = minetest.get_node_light(pos)
+		local lightval = core.get_node_light(pos)
 		digilines.receptor_send(pos, digilines.rules.default, channel, lightval)
 	end
 end
 
-minetest.register_alias("digilines_lightsensor:lightsensor", "digilines:lightsensor")
-minetest.register_node("digilines:lightsensor", {
+core.register_alias("digilines_lightsensor:lightsensor", "digilines:lightsensor")
+core.register_node("digilines:lightsensor", {
 	description = S("Digiline Lightsensor"),
 	drawtype = "nodebox",
 	tiles = {"digilines_lightsensor.png"},
@@ -47,22 +47,24 @@ minetest.register_node("digilines:lightsensor", {
 	node_box = lsensor_nodebox,
 	digilines =
 	{
-		receptor = {},
+		receptor = {
+			rules = digilines.rules.default
+		},
 		effector = {
 			action = on_digiline_receive
 		},
 	},
 	on_construct = function(pos)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		meta:set_string("formspec", "field[channel;"..FS("Channel")..";${channel}]")
 	end,
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
-		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+		if core.is_protected(pos, name) and not core.check_player_privs(name, {protection_bypass=true}) then
 			return
 		end
 		if (fields.channel) then
-			minetest.get_meta(pos):set_string("channel", fields.channel)
+			core.get_meta(pos):set_string("channel", fields.channel)
 		end
 	end,
 })
@@ -75,7 +77,7 @@ if digilines.mcl then
 	glass = "mcl_core:glass"
 end
 
-minetest.register_craft({
+core.register_craft({
 	output = "digilines:lightsensor",
 	recipe = {
 		{glass, glass, glass},

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -1,6 +1,9 @@
 local S = digilines.S
 local FS = digilines.FS
 
+local rules = digilines.rules.default
+table.insert(rules, vector.new(0, -1, 0))
+
 local GET_COMMAND = "GET"
 
 local lsensor_nodebox =
@@ -48,7 +51,7 @@ core.register_node("digilines:lightsensor", {
 	digilines =
 	{
 		receptor = {
-			rules = digilines.rules.default
+			rules = rules
 		},
 		effector = {
 			action = on_digiline_receive

--- a/lightsensor.lua
+++ b/lightsensor.lua
@@ -1,8 +1,8 @@
 local S = digilines.S
 local FS = digilines.FS
 
-local rules = digilines.rules.default
-table.insert(rules, vector.new(0, -1, 0))
+local custom_rules = table.copy(digilines.rules.default)
+table.insert(custom_rules, vector.new(0, -1, 0))
 
 local GET_COMMAND = "GET"
 
@@ -31,7 +31,7 @@ local on_digiline_receive = function (pos, _, channel, msg)
 	local setchan = core.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
 		local lightval = core.get_node_light(pos)
-		digilines.receptor_send(pos, digilines.rules.default, channel, lightval)
+		digilines.receptor_send(pos, custom_rules, channel, lightval)
 	end
 end
 
@@ -51,9 +51,10 @@ core.register_node("digilines:lightsensor", {
 	digilines =
 	{
 		receptor = {
-			rules = rules
+			rules = custom_rules
 		},
 		effector = {
+			rules = custom_rules,
 			action = on_digiline_receive
 		},
 	},

--- a/rtc.lua
+++ b/rtc.lua
@@ -20,15 +20,15 @@ local rtc_selbox =
 }
 
 local on_digiline_receive = function (pos, _, channel, msg)
-	local setchan = minetest.get_meta(pos):get_string("channel")
+	local setchan = core.get_meta(pos):get_string("channel")
 	if channel == setchan and msg == GET_COMMAND then
-		local timeofday = minetest.get_timeofday()
+		local timeofday = core.get_timeofday()
 		digilines.receptor_send(pos, digilines.rules.default, channel, timeofday)
 	end
 end
 
-minetest.register_alias("digilines_rtc:rtc", "digilines:rtc")
-minetest.register_node("digilines:rtc", {
+core.register_alias("digilines_rtc:rtc", "digilines:rtc")
+core.register_node("digilines:rtc", {
 	description = S("Digiline Real Time Clock (RTC)"),
 	drawtype = "nodebox",
 	tiles = {
@@ -52,16 +52,16 @@ minetest.register_node("digilines:rtc", {
 		},
 	},
 	on_construct = function(pos)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		meta:set_string("formspec", "field[channel;"..FS("Channel")..";${channel}]")
 	end,
 	on_receive_fields = function(pos, _, fields, sender)
 		local name = sender:get_player_name()
-		if minetest.is_protected(pos, name) and not minetest.check_player_privs(name, {protection_bypass=true}) then
+		if core.is_protected(pos, name) and not core.check_player_privs(name, {protection_bypass=true}) then
 			return
 		end
 		if (fields.channel) then
-			minetest.get_meta(pos):set_string("channel", fields.channel)
+			core.get_meta(pos):set_string("channel", fields.channel)
 		end
 	end,
 })
@@ -75,11 +75,11 @@ if digilines.mcl then
 	mese_crystal = "mesecons:redstone"
 end
 
-if minetest.get_modpath("mcl_dye") then
+if core.get_modpath("mcl_dye") then
 	dye_black = "mcl_dye:black"
 end
 
-minetest.register_craft({
+core.register_craft({
 	output = "digilines:rtc",
 	recipe = {
 		{"", dye_black, ""},

--- a/util.lua
+++ b/util.lua
@@ -102,7 +102,7 @@ local MAPBLOCKSIZE = 16
 
 -- Converts a node position into a hash of a mapblock position.
 local function vm_hash_blockpos(pos)
-	return minetest.hash_node_position({
+	return core.hash_node_position({
 		x = math.floor(pos.x / MAPBLOCKSIZE),
 		y = math.floor(pos.y / MAPBLOCKSIZE),
 		z = math.floor(pos.z / MAPBLOCKSIZE)
@@ -114,7 +114,7 @@ local function vm_get_or_create_entry(pos)
 	local hash = vm_hash_blockpos(pos)
 	local tbl = vm_cache[hash]
 	if not tbl then
-		local vm = minetest.get_voxel_manip(pos, pos)
+		local vm = core.get_voxel_manip(pos, pos)
 		local min_pos, max_pos = vm:get_emerged_area()
 		local va = VoxelArea:new{MinEdge = min_pos, MaxEdge = max_pos}
 		tbl = {va = va, data = vm:get_data(), param1 = vm:get_light_data(), param2 = vm:get_param2_data()}
@@ -130,7 +130,7 @@ local function vm_get_node(pos)
 	local node_value = tbl.data[index]
 	local node_param1 = tbl.param1[index]
 	local node_param2 = tbl.param2[index]
-	return {name = minetest.get_name_from_content_id(node_value), param1 = node_param1, param2 = node_param2}
+	return {name = core.get_name_from_content_id(node_value), param1 = node_param1, param2 = node_param2}
 end
 
 -- Gets the node at a given position, regardless of whether it is loaded or
@@ -145,12 +145,12 @@ function digilines.get_node_force(pos)
 	if vm_cache then
 		return vm_get_node(pos)
 	end
-	local node = minetest.get_node(pos)
+	local node = core.get_node(pos)
 	if node.name == "ignore" then
 		-- Node is not currently loaded; use a VoxelManipulator to prime
 		-- the mapblock cache and try again.
-		minetest.get_voxel_manip(pos, pos)
-		node = minetest.get_node(pos)
+		core.get_voxel_manip(pos, pos)
+		node = core.get_node(pos)
 	end
 	return node
 end

--- a/wire_std.lua
+++ b/wire_std.lua
@@ -83,7 +83,7 @@ for zmy=0, 1 do
 		nodebox = {-8/16, -.5, -1/16, 8/16, -.5+1/16, 1/16}
 	end
 
-	minetest.register_node("digilines:wire_std_"..nodeid, {
+	core.register_node("digilines:wire_std_"..nodeid, {
 		description = wiredesc,
 		drawtype = "nodebox",
 		tiles = tiles,

--- a/wires_common.lua
+++ b/wires_common.lua
@@ -5,8 +5,8 @@ local function check_and_update(pos, node)
 	end
 end
 
-minetest.register_on_placenode(check_and_update)
-minetest.register_on_dignode(check_and_update)
+core.register_on_placenode(check_and_update)
+core.register_on_dignode(check_and_update)
 
 function digilines.update_autoconnect(pos, secondcall)
 	local xppos = {x=pos.x+1, y=pos.y, z=pos.z}
@@ -39,7 +39,7 @@ function digilines.update_autoconnect(pos, secondcall)
 		digilines.update_autoconnect(zmympos, true)
 	end
 
-	local digilinespec = digilines.getspec(minetest.get_node(pos))
+	local digilinespec = digilines.getspec(core.get_node(pos))
 	if not (digilinespec and digilinespec.wire and
 			digilinespec.wire.use_autoconnect) then
 		return nil
@@ -80,5 +80,5 @@ function digilines.update_autoconnect(pos, secondcall)
 				tostring(xpy)..tostring(zpy)..tostring(xmy)..tostring(zmy)
 
 
-	minetest.set_node(pos, {name = digilinespec.wire.basename..nodeid})
+	core.set_node(pos, {name = digilinespec.wire.basename..nodeid})
 end


### PR DESCRIPTION
This PR does the following:

- Switches to the newer `core` namespace
- Adds a useful receptor rule to the light sensor (see below)

Previously, it was difficult to build creations that required the light sensor to be on a pole, due to the lack of conductivity directly underneath the light sensor. Adding the `x=0,y=-1,z=0` rule fixes this and provides a less annoying way to build using the sensor.

**Use case:**
<img width="2560" height="1366" alt="screenshot_20260430_150455" src="https://github.com/user-attachments/assets/4082eb09-c49a-4f5a-b707-8fe70dd7ccab" />
