### PR TITLE
Don't force deprecation of `digilines.addPosRule` and `digilines.cmpPos`

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -1,10 +1,10 @@
 digilines.addPosRule = function(p, r)
-	core.log("warning", "Call to deprecated function 'digilines.addPosRule', use 'vector.add' instead.")
+	core.log("deprecated", "Call to deprecated function 'digilines.addPosRule', use 'vector.add' instead.", 2, true)
 	return vector.add(p, r)
 end
 
 digilines.cmpPos = function(p1, p2)
-	core.log("warning", "Call to deprecated function 'digilines.cmpPos', use 'vector.equals' instead.")
+	core.log("deprecated", "Call to deprecated function 'digilines.cmpPos', use 'vector.equals' instead.", 2, true)
 	return vector.equals(p1, p2)
 end
 

--- a/util.lua
+++ b/util.lua
@@ -1,10 +1,12 @@
 digilines.addPosRule = function(p, r)
-	core.log("deprecated", "Call to deprecated function 'digilines.addPosRule', use 'vector.add' instead.", 2, true)
+	core.log("deprecated",
+		"Call to deprecated function 'digilines.addPosRule', use 'vector.add' instead.", 2, true)
 	return vector.add(p, r)
 end
 
 digilines.cmpPos = function(p1, p2)
-	core.log("deprecated", "Call to deprecated function 'digilines.cmpPos', use 'vector.equals' instead.", 2, true)
+	core.log("deprecated",
+		"Call to deprecated function 'digilines.cmpPos', use 'vector.equals' instead.", 2, true)
 	return vector.equals(p1, p2)
 end
 

--- a/util.lua
+++ b/util.lua
@@ -1,9 +1,9 @@
 digilines.addPosRule = function()
-	error("digilines.addPosRule(a,b) is deprecated. Use vector.add(a,b).")
+	core.log("warning", "Call to deprecated function 'digilines.addPosRule', use 'vector.add' instead.")
 end
 
 digilines.cmpPos = function()
-	error("digilines.cmpPos(a,b) is deprecated. Use vector.equals(a,b).")
+	core.log("warning", "Call to deprecated function 'digilines.cmpPos', use 'vector.equals' instead.")
 end
 
 --Rules rotation Functions:

--- a/util.lua
+++ b/util.lua
@@ -1,9 +1,11 @@
-digilines.addPosRule = function()
+digilines.addPosRule = function(p, r)
 	core.log("warning", "Call to deprecated function 'digilines.addPosRule', use 'vector.add' instead.")
+	return vector.add(p, r)
 end
 
-digilines.cmpPos = function()
+digilines.cmpPos = function(p1, p2)
 	core.log("warning", "Call to deprecated function 'digilines.cmpPos', use 'vector.equals' instead.")
+	return vector.equals(p1, p2)
 end
 
 --Rules rotation Functions:


### PR DESCRIPTION
Commit fe54ccb58f208207a5da05eb97df953cdb2d2f15 made `digilines.addPosRule` and `digilines.cmpPos` cause crashes when another mod used them, this PR changes the error to be a warning like deprecated engine functions.